### PR TITLE
feat(navigation): fix state persistence and improve UX

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -7,7 +7,8 @@ src/
 │   ├── btn/            # Composants boutons (DarkModeToggle, etc.)
 │   ├── filter/         # Composants de filtrage (FilterTag, ListFilterTag, FilterRemedyResult)
 │   ├── input/          # Composants d'entrée (SymptomsSelector, etc.)
-│   ├── navigation/     # Composants de navigation (BreadCrumb)
+│   ├── navigation/     # Composants de navigation (BreadCrumb avec support slug)
+│   ├── remedy/         # Composants d'affichage des remèdes (RemedyCard, RemedyResultList, RemedyResultNotFound)
 │   ├── sections/       # Sections de page (Hero, etc.)
 │   └── tag/            # Composants tags et badges (SymptomTag, ListSymptomTag)
 ├── context/            # Contextes React (ThemeContext)
@@ -17,5 +18,5 @@ src/
 │   └── components/     # Composants spécifiques au layout (LogoTradimedika)
 ├── pages/              # Pages de l'application (Home, RemedyResult, RemedyResultDetails, NotFound)
 ├── routes/             # Configuration du routage React Router (Router.jsx)
-└── utils/              # Fonctions utilitaires (normalizeSymptom, remedyMatcher)
+└── utils/              # Fonctions utilitaires (normalizeSymptom, remedyMatcher avec slug generation)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,78 @@
 
 ---
 
+## [0.9.1] - 2025-12-11
+
+### <u>add:</u>
+
+- Added `src/constants/buttonStyles.js` for reusable button styling constants
+- Added `state` prop to Link components in `RemedyCard.jsx` to pass selectedSymptoms to detail page
+- Added `state` prop to "Retour aux résultats" Link components in `RemedyResultDetails.jsx` to preserve search state
+- Added `selectedSymptoms` extraction from `location.state` in `RemedyResultDetails.jsx`
+- Added conditional `state` prop to BreadCrumb NavLink for "/remedes" path to preserve navigation state
+- Added `selectedSymptoms` prop to `RemedyResultList` component signature
+- Added `selectedSymptoms` prop to `RemedyCard` component signature
+- Added missing `motion` and `Link` imports to `RemedyResult.jsx`
+
+### <u>update:</u>
+
+- Updated `RemedyResult.jsx` to pass `selectedSymptoms` prop to `RemedyResultList` component
+- Updated `RemedyResultList.jsx` to receive and propagate `selectedSymptoms` to child `RemedyCard` components
+- Updated `RemedyCard.jsx` to receive `selectedSymptoms` and pass via Link state to detail page
+- Updated `RemedyCard.jsx` image display: changed from `aspect-video` to `aspect-square` (1:1 ratio)
+- Updated `RemedyCard.jsx` image styling: changed from `object-cover` to `object-scale-down` with `p-4` padding
+- Updated `RemedyResultDetails.jsx` to extract symptoms from `location.state` and return in both "Retour" buttons
+- Updated `RemedyResultDetails.jsx` image display: changed from `aspect-video` to `aspect-square` (1:1 ratio)
+- Updated `RemedyResultDetails.jsx` image styling: changed from `object-cover` to `object-scale-down` with `p-6` padding
+- Updated `BreadCrumb.jsx` to extract `selectedSymptoms` from `location.state` and pass to BreadcrumbItem components
+- Updated `BreadCrumbItem` function signature to accept `selectedSymptoms` prop
+- Updated `FilterTag.jsx`, `ListFilterTag.jsx`, `Hero.jsx`, and `SymptomTag.jsx` to use buttonStyles constant
+- Updated PropTypes for `RemedyResultList`, `RemedyCard`, and `BreadCrumbItem` to include `selectedSymptoms` validation
+- Updated `package.json` version from `0.9.0` to `0.9.1`
+
+### <u>refactor:</u>
+
+- Refactored button styling across components to use centralized `buttonStyles.js` constant
+- Refactored navigation state management to use React Router `location.state` for symptom persistence
+- Refactored image aspect ratios from 16:9 to 1:1 for better display of square Flaticon icons (512x512px)
+
+### <u>fix:</u>
+
+- Fixed navigation state loss when returning from remedy detail page to results page
+- Fixed "Retour aux résultats" buttons not preserving search results (both top and bottom buttons)
+- Fixed BreadCrumb "Remèdes" link not preserving state when clicked
+- Fixed search functionality from home page by adding missing imports to RemedyResult.jsx
+- Fixed image cropping issue by changing aspect ratio to square and using object-scale-down
+- Fixed images being cut off by using object-scale-down instead of object-cover
+
+### <u>optimization:</u>
+
+- Optimized image display quality by preventing upscaling with object-scale-down
+- Optimized navigation UX by preserving search context across page transitions
+- Optimized code reusability with centralized button styling constants
+
+### <u>standardization:</u>
+
+- Standardized image aspect ratio across remedy cards and details pages (1:1 square)
+- Standardized state passing pattern for selectedSymptoms across navigation chain
+- Standardized button styling with reusable constants across filter and tag components
+- Established navigation state persistence pattern using React Router location.state
+
+### <u>features:</u>
+
+- **Navigation State Persistence**: Search results now persist when navigating between remedy list and detail pages
+- **Improved Image Display**: Full icons displayed without cropping using 1:1 aspect ratio and object-scale-down
+- **State-Aware BreadCrumb**: Clicking "Remèdes" in breadcrumb preserves search results
+- **Centralized Button Styles**: Reusable styling constants for consistent UI across components
+
+### <u>issues resolved:</u>
+
+- User-reported bug: Navigation state loss when returning from detail page showing empty results
+- User-reported bug: Search from home page not displaying remedies (missing imports)
+- User-reported UX issue: Images being cropped due to 16:9 aspect ratio on square icons
+
+---
+
 ## [0.9.0] - 2025-12-10
 
 ### <u>add:</u>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,67 @@
 
 ---
 
+## [0.9.0] - 2025-12-10
+
+### <u>add:</u>
+
+- Added `generateSlug()` function in `src/utils/remedyMatcher.js` for URL-safe slug generation from remedy names
+- Added `getRemedyBySlug()` function in `src/utils/remedyMatcher.js` for fetching remedies by slug instead of ID
+- Added complete implementation of `RemedyResultDetails.jsx` page with mobile-first responsive design
+- Added Hero section with remedy image, type badge, and safety badges (pregnancy, children age, verified)
+- Added structured sections for properties, symptoms, uses, contraindications, tips, and allergens
+- Added conditional rendering for all remedy data fields (only shows if data exists)
+- Added warning/info cards with colored borders for contraindications (red), tips (blue), and allergens (yellow)
+- Added compact usage display format (form + dose + frequency on one line)
+- Added static back button below breadcrumb navigation
+- Added Framer Motion animations for page entry, staggered sections, and image hover
+- Added `RemedyResultNotFound` component integration for invalid remedy slugs
+- Added ARIA accessibility attributes (`aria-label`, semantic HTML)
+- Added dark mode support across all remedy detail sections
+
+### <u>update:</u>
+
+- Updated `src/routes/Router.jsx` to use `:slug` parameter instead of `:id` for remedy routes
+- Updated route path from `/remedies/:id` to `/remedes/:slug` (French URL)
+- Updated `RemedyResultDetails.jsx` to fetch remedies using `getRemedyBySlug()` instead of `getRemedyById()`
+- Updated `BreadCrumb.jsx` to display remedy name dynamically instead of "Remède #ID"
+- Updated `BreadCrumb.jsx` to fetch remedy data using `getRemedyBySlug()` for label generation
+- Updated `segmentToLabel()` function to accept `remedyName` parameter
+- Updated `buildBreadcrumbPath()` function to pass remedy name to label generator
+- Updated `RemedyCard.jsx` to generate navigation links with slugs using `generateSlug(name)`
+- Updated all internal links from `/remedies` to `/remedes` in `RemedyResultDetails.jsx`
+- Updated `BreadCrumb.jsx` labels mapping to support `/remedes` route
+- Updated `package.json` version from `0.8.0` to `0.9.0`
+- Updated `README.md` version badge from `0.8.0` to `0.9.0`
+
+### <u>refactor:</u>
+
+- Refactored `RemedyResultDetails.jsx` from placeholder to fully functional detail page (56 lines → 435 lines)
+- Refactored URL structure from numeric IDs (`/remedies/0`) to semantic slugs (`/remedes/citron`)
+- Refactored breadcrumb logic to dynamically fetch and display remedy names
+- Extracted slug generation logic into reusable utility function
+- Simplified remedy lookup by slug with comprehensive error handling
+
+### <u>optimization:</u>
+
+- Optimized slug generation to preserve French accents (SEO-friendly URLs: `thé-vert`, `jus-de-citron`)
+- Optimized breadcrumb rendering by fetching remedy data only when `params.slug` exists
+- Removed unused `id` destructuring from `RemedyCard.jsx` (now uses `name` for slug generation)
+
+### <u>standardization:</u>
+
+- Standardized URL pattern across application: all remedy links now use slug-based navigation
+- Standardized breadcrumb display format: "Accueil > Remèdes > [Nom du remède]"
+- Standardized route naming: consistent use of `/remedes` (French) instead of `/remedies` (English)
+
+### <u>issues resolved:</u>
+
+- Issue #49: Implementation of remedy result details page with complete data display
+- User request: Breadcrumb now displays remedy name instead of "Remède #ID"
+- User request: URLs now use semantic slugs instead of numeric IDs
+
+---
+
 ## [0.8.1] - 2025-12-10
 
 ### <u>documentation:</u>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [🌐 **Voir le site**](https://pierremaze.github.io/tradimedika/) • [🐛 **Signaler un bug**](https://github.com/PierreMaze/) • [💬 **Discuter**](https://www.linkedin.com/in/pierremazelaygue/)
 
-[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.9.0)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
+[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.9.1)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
 
 </div>
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [🌐 **Voir le site**](https://pierremaze.github.io/tradimedika/) • [🐛 **Signaler un bug**](https://github.com/PierreMaze/) • [💬 **Discuter**](https://www.linkedin.com/in/pierremazelaygue/)
 
-[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.8.0)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
+[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.9.0)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
 
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tradimedika",
   "private": true,
-  "version": "0.8.0",
+  "version": "0.9.0",
   "type": "module",
   "homepage": "http://pierremaze.github.io/tradimedika",
   "prettier": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tradimedika",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.1",
   "type": "module",
   "homepage": "http://pierremaze.github.io/tradimedika",
   "prettier": {

--- a/src/components/filter/FilterTag.jsx
+++ b/src/components/filter/FilterTag.jsx
@@ -1,6 +1,7 @@
 // components/filter/FilterTag.jsx
 import { motion } from "framer-motion";
 import PropTypes from "prop-types";
+import { BUTTON_PRIMARY_STYLES } from "../../constants/buttonStyles";
 
 /**
  * Composant Tag individuel pour filtrer les remèdes
@@ -21,10 +22,10 @@ export default function FilterTag({ label, isActive, onClick }) {
       aria-pressed={isActive}
       aria-label={`Filtrer par ${label}`}
       type="button"
-      className={`cursor-pointer rounded-md px-3 py-2 text-sm font-medium tracking-wider shadow-md transition duration-150 ease-in-out hover:scale-105 focus:ring-2 focus:ring-emerald-300 focus:outline-none lg:text-base ${
+      className={`cursor-pointer rounded-md px-3 py-2 text-sm font-medium tracking-wider shadow-md transition duration-150 ease-in-out lg:text-base ${
         isActive
-          ? "bg-emerald-600 text-white dark:bg-emerald-700"
-          : "bg-neutral-200 text-neutral-700 hover:bg-neutral-300 dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-600"
+          ? BUTTON_PRIMARY_STYLES
+          : "bg-neutral-200 text-neutral-900 hover:bg-emerald-600 hover:text-white dark:bg-neutral-700 dark:text-neutral-300 dark:hover:bg-neutral-600"
       }`}
     >
       {label}

--- a/src/components/filter/ListFilterTag.jsx
+++ b/src/components/filter/ListFilterTag.jsx
@@ -23,7 +23,7 @@ export default function ListFilterTag({ tags, activeTag, onTagClick }) {
       initial={{ opacity: 0, y: -10 }}
       animate={{ opacity: 1, y: 0 }}
       transition={{ duration: 0.3 }}
-      className="mx-auto flex flex-wrap items-center justify-center gap-2 lg:justify-start"
+      className="mx-auto flex flex-wrap items-center justify-center gap-2"
       role="group"
       aria-label="Filtrer les remèdes par symptôme"
     >

--- a/src/components/navigation/BreadCrumb.jsx
+++ b/src/components/navigation/BreadCrumb.jsx
@@ -3,6 +3,8 @@ import PropTypes from "prop-types";
 import { IoChevronForward } from "react-icons/io5";
 import { NavLink, useLocation, useParams } from "react-router-dom";
 import { LINK_INTERNAL_STYLES } from "../../constants/linkStyles";
+import db from "../../data/db.json";
+import { getRemedyBySlug } from "../../utils/remedyMatcher";
 
 /**
  * BreadCrumb Component - Navigation breadcrumb trail
@@ -13,7 +15,7 @@ import { LINK_INTERNAL_STYLES } from "../../constants/linkStyles";
  * Hierarchy:
  * - / → "Accueil"
  * - /remedies → "Accueil > Remèdes"
- * - /remedies/:id → "Accueil > Remèdes > Remède #X"
+ * - /remedies/:slug → "Accueil > Remèdes > [Nom du remède]"
  *
  * Features:
  * - Dynamic path generation using useLocation()
@@ -25,17 +27,18 @@ import { LINK_INTERNAL_STYLES } from "../../constants/linkStyles";
 
 /**
  * Convert URL segment to readable label
- * @param {string} segment - URL segment (e.g., "remedies", "5")
- * @param {boolean} isId - Whether segment is a dynamic ID
+ * @param {string} segment - URL segment (e.g., "remedies", "citron")
+ * @param {boolean} isSlug - Whether segment is a remedy slug
+ * @param {string|null} remedyName - Name of the remedy if found
  * @returns {string} Human-readable label
  */
-const segmentToLabel = (segment, isId = false) => {
-  if (isId) {
-    return `Remède #${segment}`;
+const segmentToLabel = (segment, isSlug = false, remedyName = null) => {
+  if (isSlug && remedyName) {
+    return remedyName; // Affiche "Citron" au lieu de "citron"
   }
 
   const labels = {
-    remedies: "Remèdes",
+    remedes: "Remèdes",
   };
 
   return labels[segment] || segment;
@@ -45,9 +48,10 @@ const segmentToLabel = (segment, isId = false) => {
  * Build breadcrumb path array from current location
  * @param {string} pathname - Current URL pathname
  * @param {Object} params - URL parameters from useParams()
+ * @param {string|null} remedyName - Name of the remedy if on detail page
  * @returns {Array} Array of {label, path} objects
  */
-const buildBreadcrumbPath = (pathname, params) => {
+const buildBreadcrumbPath = (pathname, params, remedyName = null) => {
   const breadcrumbs = [{ label: "Accueil", path: "/" }];
 
   // Remove leading/trailing slashes and split
@@ -60,10 +64,10 @@ const buildBreadcrumbPath = (pathname, params) => {
     if (!segment) return; // Skip empty segments
 
     currentPath += `/${segment}`;
-    const isId = params.id && segment === params.id;
+    const isSlug = params.slug && segment === params.slug;
 
     breadcrumbs.push({
-      label: segmentToLabel(segment, isId),
+      label: segmentToLabel(segment, isSlug, remedyName),
       path: currentPath,
     });
   });
@@ -115,8 +119,15 @@ function BreadCrumb() {
   const location = useLocation();
   const params = useParams();
 
+  // Récupérer le remède si on est sur une page de détail
+  const remedy = params.slug ? getRemedyBySlug(params.slug, db) : null;
+
   // Build breadcrumb path from current route
-  const pathSegments = buildBreadcrumbPath(location.pathname, params);
+  const pathSegments = buildBreadcrumbPath(
+    location.pathname,
+    params,
+    remedy?.name,
+  );
 
   // Don't show breadcrumb on home page (only one segment)
   if (pathSegments.length <= 1) {

--- a/src/components/navigation/BreadCrumb.jsx
+++ b/src/components/navigation/BreadCrumb.jsx
@@ -78,13 +78,18 @@ const buildBreadcrumbPath = (pathname, params, remedyName = null) => {
 /**
  * BreadcrumbItem - Individual breadcrumb link or text
  */
-function BreadcrumbItem({ item, isLast }) {
+function BreadcrumbItem({ item, isLast, selectedSymptoms }) {
   return (
     <li className="flex items-center gap-2">
       {!isLast ? (
         <>
           <NavLink
             to={item.path}
+            state={
+              item.path === "/remedes" && selectedSymptoms.length > 0
+                ? { symptoms: selectedSymptoms }
+                : undefined
+            }
             className={LINK_INTERNAL_STYLES}
             aria-label={`Naviguer vers ${item.label}`}
           >
@@ -110,6 +115,7 @@ BreadcrumbItem.propTypes = {
     path: PropTypes.string.isRequired,
   }).isRequired,
   isLast: PropTypes.bool.isRequired,
+  selectedSymptoms: PropTypes.arrayOf(PropTypes.string).isRequired,
 };
 
 /**
@@ -118,6 +124,7 @@ BreadcrumbItem.propTypes = {
 function BreadCrumb() {
   const location = useLocation();
   const params = useParams();
+  const selectedSymptoms = location.state?.symptoms || [];
 
   // Récupérer le remède si on est sur une page de détail
   const remedy = params.slug ? getRemedyBySlug(params.slug, db) : null;
@@ -142,6 +149,7 @@ function BreadCrumb() {
             key={item.path}
             item={item}
             isLast={index === pathSegments.length - 1}
+            selectedSymptoms={selectedSymptoms}
           />
         ))}
       </ol>

--- a/src/components/remedy/RemedyCard.jsx
+++ b/src/components/remedy/RemedyCard.jsx
@@ -2,10 +2,11 @@
 import { motion } from "framer-motion";
 import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import { generateSlug } from "../../utils/remedyMatcher";
 
 /**
  * Carte individuelle pour afficher un remède
- * - Entièrement cliquable (wrapper Link vers /remedies/:id)
+ * - Entièrement cliquable (wrapper Link vers /remedes/:slug)
  * - Affiche: image, nom, type, description, propriétés, sécurité grossesse, âge enfants, vérification professionnelle
  * - Design responsive avec animations Framer Motion
  * - Support mode sombre
@@ -13,7 +14,6 @@ import PropTypes from "prop-types";
  */
 export default function RemedyCard({ remedy }) {
   const {
-    id,
     name,
     type,
     description,
@@ -40,7 +40,7 @@ export default function RemedyCard({ remedy }) {
       transition={{ duration: 0.3 }}
     >
       <Link
-        to={`/remedies/${id}`}
+        to={`/remedes/${generateSlug(name)}`}
         aria-label={`Voir les détails de ${name}`}
         className="block h-full"
       >

--- a/src/components/remedy/RemedyCard.jsx
+++ b/src/components/remedy/RemedyCard.jsx
@@ -1,9 +1,9 @@
 // components/remedy/RemedyCard.jsx
 import { motion } from "framer-motion";
-import { Link } from "react-router-dom";
 import PropTypes from "prop-types";
+import { Link } from "react-router-dom";
+import { capitalizeFirstLetter } from "../../utils/capitalizeFirstLetter";
 import { generateSlug } from "../../utils/remedyMatcher";
-
 /**
  * Carte individuelle pour afficher un remède
  * - Entièrement cliquable (wrapper Link vers /remedes/:slug)
@@ -26,7 +26,9 @@ export default function RemedyCard({ remedy }) {
 
   // Type badges avec couleurs différentes
   const typeStyles = {
-    aliment: "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    aliment:
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    boisson: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
     épice:
       "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
     plante: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
@@ -72,7 +74,7 @@ export default function RemedyCard({ remedy }) {
             </div>
 
             {/* Description */}
-            <p className="mb-4 line-clamp-3 text-sm text-neutral-600 lg:text-base dark:text-neutral-400">
+            <p className="mb-4 line-clamp-3 text-start text-sm text-neutral-600 lg:text-base dark:text-neutral-400">
               {description}
             </p>
 
@@ -82,12 +84,9 @@ export default function RemedyCard({ remedy }) {
                 {properties.slice(0, 3).map((prop, index) => (
                   <span
                     key={index}
-                    className="inline-flex items-center gap-1 rounded-full bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200"
+                    className="inline-flex items-center gap-1 rounded-md bg-emerald-100 px-3 py-1 text-xs font-medium text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200"
                   >
-                    {prop.name}
-                    <span className="text-xs opacity-75">
-                      ({prop.score}/10)
-                    </span>
+                    {capitalizeFirstLetter(prop.name, true)}
                   </span>
                 ))}
                 {properties.length > 3 && (
@@ -100,9 +99,32 @@ export default function RemedyCard({ remedy }) {
 
             {/* Badges de sécurité */}
             <div className="flex flex-wrap gap-2">
+              {verifiedByProfessional && (
+                <span
+                  className="inline-flex items-center gap-1 rounded-md bg-sky-100 px-2 py-1 text-xs font-medium text-sky-800 dark:bg-sky-900 dark:text-sky-200"
+                  title="Vérifié par un professionnel de santé"
+                >
+                  <svg
+                    className="h-4 w-4"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                    aria-hidden="true"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
+                    />
+                  </svg>
+                  Vérifié
+                </span>
+              )}
+
               {pregnancySafe && (
                 <span
-                  className="inline-flex items-center gap-1 rounded-md bg-purple-100 px-2 py-1 text-xs font-medium text-purple-800 dark:bg-purple-900 dark:text-purple-200"
+                  className="inline-flex items-center gap-1 rounded-md bg-lime-100 px-2 py-1 text-xs font-medium text-lime-800 dark:bg-lime-900 dark:text-lime-200"
                   title="Sûr pendant la grossesse"
                 >
                   <svg
@@ -125,7 +147,7 @@ export default function RemedyCard({ remedy }) {
 
               {childrenAge !== null && (
                 <span
-                  className="inline-flex items-center gap-1 rounded-md bg-pink-100 px-2 py-1 text-xs font-medium text-pink-800 dark:bg-pink-900 dark:text-pink-200"
+                  className="inline-flex items-center gap-1 rounded-md bg-blue-100 px-2 py-1 text-xs font-medium text-blue-800 dark:bg-blue-900 dark:text-blue-200"
                   title={`Adapté aux enfants de ${childrenAge} ans et plus`}
                 >
                   <svg
@@ -143,29 +165,6 @@ export default function RemedyCard({ remedy }) {
                     />
                   </svg>
                   {childrenAge}+ ans
-                </span>
-              )}
-
-              {verifiedByProfessional && (
-                <span
-                  className="inline-flex items-center gap-1 rounded-md bg-teal-100 px-2 py-1 text-xs font-medium text-teal-800 dark:bg-teal-900 dark:text-teal-200"
-                  title="Vérifié par un professionnel de santé"
-                >
-                  <svg
-                    className="h-4 w-4"
-                    fill="none"
-                    stroke="currentColor"
-                    viewBox="0 0 24 24"
-                    aria-hidden="true"
-                  >
-                    <path
-                      strokeLinecap="round"
-                      strokeLinejoin="round"
-                      strokeWidth={2}
-                      d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"
-                    />
-                  </svg>
-                  Vérifié
                 </span>
               )}
             </div>

--- a/src/components/remedy/RemedyCard.jsx
+++ b/src/components/remedy/RemedyCard.jsx
@@ -12,7 +12,7 @@ import { generateSlug } from "../../utils/remedyMatcher";
  * - Support mode sombre
  * - Accessible avec aria-label
  */
-export default function RemedyCard({ remedy }) {
+export default function RemedyCard({ remedy, selectedSymptoms }) {
   const {
     name,
     type,
@@ -43,27 +43,28 @@ export default function RemedyCard({ remedy }) {
     >
       <Link
         to={`/remedes/${generateSlug(name)}`}
+        state={{ symptoms: selectedSymptoms }}
         aria-label={`Voir les détails de ${name}`}
         className="block h-full"
       >
-        <div className="group h-full overflow-hidden rounded-lg border border-neutral-200 bg-white shadow-md transition duration-300 ease-in-out hover:scale-102 hover:shadow-lg dark:border-neutral-700 dark:bg-neutral-800">
+        <div className="group h-full overflow-hidden rounded-lg bg-white shadow-md ring-2 ring-neutral-300 transition duration-300 ease-in-out hover:shadow-lg hover:ring-emerald-500 dark:bg-neutral-800 dark:ring-neutral-600">
           {/* Image */}
           {image && (
-            <div className="aspect-video w-full overflow-hidden bg-neutral-100 dark:bg-neutral-700">
+            <div className="aspect-square w-full overflow-hidden bg-neutral-50 dark:bg-neutral-700">
               <img
                 src={image}
                 alt={`Illustration de ${name}`}
-                className="h-full w-full object-cover transition duration-300 group-hover:scale-105"
+                className="mx-auto h-full w-2/3 object-scale-down p-4 transition duration-300 lg:w-3/4 2xl:w-4/5"
                 loading="lazy"
               />
             </div>
           )}
 
           {/* Contenu */}
-          <div className="p-4 lg:p-6">
+          <div className="p-6">
             {/* En-tête avec nom et type */}
             <div className="mb-3 flex items-start justify-between gap-2">
-              <h3 className="text-xl font-bold text-neutral-900 lg:text-2xl dark:text-neutral-100">
+              <h3 className="text-start text-xl font-bold text-neutral-900 lg:text-2xl dark:text-neutral-100">
                 {name}
               </h3>
               <span
@@ -193,4 +194,5 @@ RemedyCard.propTypes = {
     childrenAge: PropTypes.number,
     verifiedByProfessional: PropTypes.bool,
   }).isRequired,
+  selectedSymptoms: PropTypes.arrayOf(PropTypes.string).isRequired,
 };

--- a/src/components/remedy/RemedyResultList.jsx
+++ b/src/components/remedy/RemedyResultList.jsx
@@ -12,7 +12,11 @@ import RemedyResultNotFound from "./RemedyResultNotFound";
  * - Utilise AnimatePresence pour les animations enter/exit
  * - Gère deux scénarios d'état vide (pas de résultats initiaux vs pas de correspondance après filtrage)
  */
-export default function RemedyResultList({ remedies, hasMatchingRemedies }) {
+export default function RemedyResultList({
+  remedies,
+  hasMatchingRemedies,
+  selectedSymptoms,
+}) {
   // Si aucun remède dans la liste filtrée
   if (remedies.length === 0) {
     // Si hasMatchingRemedies est true, cela signifie qu'il y a des résultats mais le filtre les exclut tous
@@ -29,9 +33,13 @@ export default function RemedyResultList({ remedies, hasMatchingRemedies }) {
     <div className="w-full">
       {/* Grille responsive pour les cartes de remèdes */}
       <AnimatePresence mode="sync">
-        <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+        <div className="mx-4 grid grid-cols-1 gap-6 md:grid-cols-2 lg:-mx-4 lg:grid-cols-3 2xl:gap-12">
           {remedies.map((result) => (
-            <RemedyCard key={result.remedy.id} remedy={result.remedy} />
+            <RemedyCard
+              key={result.remedy.id}
+              remedy={result.remedy}
+              selectedSymptoms={selectedSymptoms}
+            />
           ))}
         </div>
       </AnimatePresence>
@@ -48,4 +56,5 @@ RemedyResultList.propTypes = {
     }),
   ).isRequired,
   hasMatchingRemedies: PropTypes.bool.isRequired,
+  selectedSymptoms: PropTypes.arrayOf(PropTypes.string).isRequired,
 };

--- a/src/components/sections/Hero.jsx
+++ b/src/components/sections/Hero.jsx
@@ -9,6 +9,7 @@ import { useSymptomTags } from "../../hooks/useSymptomTags";
 import LeafFall from "../LeafFall";
 import SymptomsSelector from "../input/SymptomsSelector";
 import ListSymptomTag from "../tag/ListSymptomTag";
+import { BUTTON_PRIMARY_STYLES } from "../../constants/buttonStyles";
 
 /**
  * Composant wrapper pour isoler le state des symptômes
@@ -67,13 +68,13 @@ function SymptomsSection() {
         }
         aria-busy={isLoading}
         aria-disabled={isDisabled}
-        whileHover={!isDisabled && !isLoading ? { scale: 1.05 } : {}}
-        whileTap={!isDisabled && !isLoading ? { scale: 0.95 } : {}}
+        whileHover={!isDisabled && !isLoading}
+        whileTap={!isDisabled && !isLoading}
         transition={{ duration: 0.2 }}
         className={`mx-auto flex w-full items-center justify-center gap-2 rounded-lg px-7 py-3.5 font-semibold shadow-lg transition duration-300 ease-in-out md:max-w-80 lg:text-base 2xl:text-lg ${
           isDisabled || isLoading
             ? "cursor-not-allowed bg-neutral-400 opacity-50 dark:bg-neutral-600"
-            : "bg-emerald-600 text-white hover:bg-emerald-600/90 dark:bg-emerald-700 dark:hover:bg-emerald-700/90"
+            : BUTTON_PRIMARY_STYLES
         }`}
       >
         {isLoading ? (

--- a/src/components/tag/SymptomTag.jsx
+++ b/src/components/tag/SymptomTag.jsx
@@ -2,6 +2,7 @@
 import { motion } from "framer-motion";
 import PropTypes from "prop-types";
 import { IoMdClose } from "react-icons/io";
+import { BUTTON_PRIMARY_STYLES } from "../../constants/buttonStyles";
 
 // Fonction helper pour capitaliser la première lettre
 const capitalizeSymptom = (symptom) => {
@@ -23,7 +24,7 @@ export default function SymptomTag({ symptom, onRemove }) {
       transition={{ duration: 0.3 }}
       onClick={() => onRemove(symptom)}
       aria-label={`Supprimer ${symptom}`}
-      className="flex cursor-pointer items-center gap-2 rounded-md bg-emerald-600 px-3 py-2 text-white shadow-md transition duration-150 ease-in-out hover:scale-105 hover:bg-emerald-600 focus:ring-2 focus:ring-emerald-300 focus:outline-none dark:bg-emerald-700 dark:hover:bg-emerald-600"
+      className={`flex cursor-pointer items-center gap-2 rounded-md px-3 py-2 shadow-md ${BUTTON_PRIMARY_STYLES}`}
     >
       <span className="text-sm font-medium tracking-wider lg:text-base">
         {capitalizeSymptom(symptom)}

--- a/src/constants/buttonStyles.js
+++ b/src/constants/buttonStyles.js
@@ -1,0 +1,21 @@
+// tradimedika-v1/src/constants/buttonStyles.js
+
+/**
+ * Link Styles Constants
+ *
+ * Centralized styling constants for internal and external links.
+ * Ensures visual consistency across the application.
+ */
+
+/**
+ * Internal link styles (React Router NavLink/Link)
+ * @type {string}
+ */
+export const BUTTON_PRIMARY_STYLES =
+  "bg-emerald-600 text-white transition duration-150 ease-in-out hover:bg-emerald-700 dark:bg-emerald-700 dark:hover:bg-emerald-600";
+
+/**
+ * External link styles (HTML anchor tags)
+ * @type {string}
+ */
+export const UTTON_SECONDARY_STYLES = " rounded-md";

--- a/src/data/db.json
+++ b/src/data/db.json
@@ -30,7 +30,7 @@
       "Faire un test de tolérance sur 3 jours",
       "Le citron ne 'nettoie' pas le foie - c'est un mythe"
     ],
-    "image": "https://cdn.pixabay.com/photo/2016/03/31/21/16/citrus-1296291_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/4056/4056931.png",
     "pregnancySafe": true,
     "childrenAge": null,
     "allergens": ["agrumes"],
@@ -67,7 +67,7 @@
       "Efficacité non prouvée scientifiquement",
       "Ne remplace pas un traitement médical"
     ],
-    "image": "https://cdn.pixabay.com/photo/2014/12/21/23/59/onion-576534_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/15618/15618168.png",
     "pregnancySafe": true,
     "childrenAge": null,
     "allergens": [],
@@ -108,7 +108,7 @@
       "Ne pas dépasser 2 jours d'utilisation",
       "Arrêter en cas d'irritation"
     ],
-    "image": "clove",
+    "image": "https://cdn-icons-png.flaticon.com/512/7014/7014075.png ",
     "pregnancySafe": false,
     "childrenAge": 12,
     "allergens": [],
@@ -145,7 +145,7 @@
       "Ne pas chauffer au-delà de 40°C pour préserver les propriétés",
       "Choisir du miel brut et local si possible"
     ],
-    "image": "https://cdn.pixabay.com/photo/2013/07/13/10/14/honey-156826_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/3413/3413290.png ",
     "pregnancySafe": true,
     "childrenAge": 1,
     "allergens": ["pollen"],
@@ -185,7 +185,7 @@
       "Arrêter 1 semaine avant toute chirurgie",
       "Peut causer une mauvaise haleine"
     ],
-    "image": "https://cdn.pixabay.com/photo/2024/07/12/16/51/garlic-8890743_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/15618/15618172.png",
     "pregnancySafe": false,
     "childrenAge": null,
     "allergens": [],
@@ -218,7 +218,7 @@
       "Ne dispense pas de consulter si la diarrhée persiste",
       "Penser à bien s'hydrater en parallèle"
     ],
-    "image": "https://cdn.pixabay.com/photo/2022/04/21/12/34/rice-grains-7147376_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/2714/2714036.png",
     "pregnancySafe": true,
     "childrenAge": null,
     "allergens": [],
@@ -255,7 +255,7 @@
       "Effet prébiotique bénéfique pour la flore intestinale",
       "Peut causer des ballonnements chez certaines personnes"
     ],
-    "image": "https://cdn.pixabay.com/photo/2016/03/31/22/00/banana-1296779_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/17502/17502228.png",
     "pregnancySafe": true,
     "childrenAge": null,
     "allergens": ["pollen"],
@@ -298,7 +298,7 @@
       "Efficacité scientifiquement prouvée",
       "Gingembre frais > poudre pour les propriétés"
     ],
-    "image": "https://cdn.pixabay.com/photo/2016/03/31/15/40/ginger-1293466_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/5281/5281043.png",
     "pregnancySafe": null,
     "childrenAge": 6,
     "allergens": [],
@@ -345,7 +345,7 @@
       "Boire le soir pour meilleur effet sur le sommeil",
       "Études validant les effets anti-dépression post-partum"
     ],
-    "image": "https://cdn.pixabay.com/photo/2021/03/14/14/24/chamomile-6094459_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/8669/8669890.png",
     "pregnancySafe": false,
     "childrenAge": 12,
     "allergens": ["asteracees"],
@@ -386,7 +386,7 @@
       "Ne pas utiliser huile essentielle chez enfants <6 ans",
       "Excellente pour syndrome intestin irritable (sauf RGO)"
     ],
-    "image": "https://cdn.pixabay.com/photo/2013/07/12/17/46/mint-152410_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/6692/6692125.png",
     "pregnancySafe": false,
     "childrenAge": 6,
     "allergens": [],
@@ -429,7 +429,7 @@
       "Consommation excessive = fatigue paradoxale",
       "Risque de dépendance et symptômes de sevrage"
     ],
-    "image": "https://cdn.pixabay.com/photo/2018/02/24/10/01/coffee-3177691_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/3219/3219300.png",
     "pregnancySafe": null,
     "childrenAge": 12,
     "allergens": [],
@@ -468,7 +468,7 @@
       "Consulter professionnel santé avant usage si traitement en cours",
       "Ne pas utiliser baies crues (toxiques)"
     ],
-    "image": "https://binette-et-jardin.ouest-france.fr/images/dossiers/historique/sureau-100541.jpg",
+    "image": "https://cdn-icons-png.flaticon.com/512/12924/12924832.png",
     "pregnancySafe": false,
     "childrenAge": 2,
     "allergens": [],
@@ -509,7 +509,7 @@
       "Risque allergie croisée : pollen olive, venin abeille",
       "Arrêter avant toute intervention chirurgicale"
     ],
-    "image": "https://cdn.pixabay.com/photo/2014/12/22/00/00/pineapples-576576_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/18651/18651070.png",
     "pregnancySafe": true,
     "childrenAge": 6,
     "allergens": ["pollen olive", "venin abeille"],
@@ -548,7 +548,7 @@
       "Le sorbitol peut aggraver symptômes du Syndrome de l'intestin irritable (SII)",
       "Intégrer dans alimentation équilibrée"
     ],
-    "image": "https://cdn.pixabay.com/photo/2012/04/12/13/27/plum-30034_1280.png",
+    "image": "https://cdn-icons-png.flaticon.com/512/15841/15841651.png",
     "pregnancySafe": true,
     "childrenAge": null,
     "allergens": [],

--- a/src/hooks/useSymptomSubmit.js
+++ b/src/hooks/useSymptomSubmit.js
@@ -52,7 +52,7 @@ export function useSymptomSubmit() {
         setHasSubmitted(true);
 
         // Navigation vers la page des résultats avec les symptômes en state
-        navigate("/remedies", {
+        navigate("/remedes", {
           state: { symptoms: selectedSymptoms },
         });
 

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,6 +1,6 @@
 // tradimedika-v1/src/pages/NotFound.jsx
-import { Link } from "react-router-dom";
 import { motion } from "framer-motion";
+import { Link } from "react-router-dom";
 
 /**
  * NotFound Page - 404 Error Handler
@@ -46,7 +46,7 @@ function NotFound() {
             Retour à l&apos;accueil
           </Link>
           <Link
-            to="/remedies"
+            to="/remedes"
             className="rounded-lg border-2 border-emerald-600 px-6 py-3 font-semibold text-emerald-600 transition duration-200 hover:bg-emerald-50 dark:hover:bg-emerald-950"
           >
             Explorer les remèdes

--- a/src/pages/RemedyResult.jsx
+++ b/src/pages/RemedyResult.jsx
@@ -1,7 +1,8 @@
 // tradimedika-v1/src/pages/RemedyResult.jsx
 
 import { useMemo, useState } from "react";
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
+import { motion } from "framer-motion";
 import FilterRemedyResult from "../components/filter/FilterRemedyResult";
 import RemedyResultList from "../components/remedy/RemedyResultList";
 import db from "../data/db.json";
@@ -41,48 +42,78 @@ function RemedyResult() {
   const [filteredRemedies, setFilteredRemedies] = useState(matchedRemedies);
 
   return (
-    <div className="text-dark dark:text-light flex flex-col items-center text-center transition duration-300 ease-in-out">
-      {/* Titre principal */}
-      <h1 className="mb-6 text-3xl font-bold lg:text-4xl">
-        Résultats des Remèdes
-      </h1>
+    <>
+      {/* Bouton Retour */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+        className="mb-6"
+      >
+        <Link
+          to="/"
+          aria-label="Retour à l'accueil"
+          className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:ring-2 focus:ring-emerald-300 focus:outline-none"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+        </Link>
+      </motion.div>
+      <div className="text-dark dark:text-light flex flex-col items-center text-center transition duration-300 ease-in-out">
+        {/* Titre principal */}
+        <h1 className="mb-6 text-3xl font-bold lg:text-4xl">
+          Résultats des Remèdes
+        </h1>
 
-      {/* Sous-titre avec symptômes sélectionnés */}
-      {selectedSymptoms.length > 0 && (
-        <p className="mb-6 text-base text-neutral-600 lg:text-lg dark:text-neutral-400">
-          Remèdes naturels pour:{" "}
-          <span className="font-semibold text-emerald-600 dark:text-emerald-500">
-            {selectedSymptoms.join(", ")}
-          </span>
-        </p>
-      )}
+        {/* Sous-titre avec symptômes sélectionnés */}
+        {selectedSymptoms.length > 0 && (
+          <p className="mb-6 text-center text-base text-neutral-600 lg:text-lg dark:text-neutral-400">
+            Remèdes naturels pour:{" "}
+            <span className="font-semibold text-emerald-600 dark:text-emerald-500">
+              {selectedSymptoms.join(", ")}
+            </span>
+          </p>
+        )}
 
-      {/* Filtres par tags (seulement si des remèdes ont été trouvés) */}
-      {matchedRemedies.length > 0 && (
-        <FilterRemedyResult
-          key={selectedSymptoms.join("-")}
-          matchedRemedies={matchedRemedies}
-          onFilterChange={setFilteredRemedies}
+        {/* Filtres par tags (seulement si des remèdes ont été trouvés) */}
+        {matchedRemedies.length > 0 && (
+          <FilterRemedyResult
+            key={selectedSymptoms.join("-")}
+            matchedRemedies={matchedRemedies}
+            onFilterChange={setFilteredRemedies}
+          />
+        )}
+
+        {/* Compteur de résultats (seulement si des remèdes sont affichés après filtrage) */}
+        {filteredRemedies.length > 0 && matchedRemedies.length > 0 && (
+          <p className="mb-6 text-lg text-neutral-600 dark:text-neutral-400">
+            <span className="font-bold text-emerald-600 dark:text-emerald-500">
+              {filteredRemedies.length}
+            </span>{" "}
+            remède{filteredRemedies.length > 1 ? "s" : ""} trouvé
+            {filteredRemedies.length > 1 ? "s" : ""}
+          </p>
+        )}
+
+        {/* Liste des remèdes ou état vide */}
+        <RemedyResultList
+          remedies={filteredRemedies}
+          hasMatchingRemedies={matchedRemedies.length > 0}
+          selectedSymptoms={selectedSymptoms}
         />
-      )}
-
-      {/* Compteur de résultats (seulement si des remèdes sont affichés après filtrage) */}
-      {filteredRemedies.length > 0 && matchedRemedies.length > 0 && (
-        <p className="mb-6 text-lg text-neutral-600 dark:text-neutral-400">
-          <span className="font-bold text-emerald-600 dark:text-emerald-500">
-            {filteredRemedies.length}
-          </span>{" "}
-          remède{filteredRemedies.length > 1 ? "s" : ""} trouvé
-          {filteredRemedies.length > 1 ? "s" : ""}
-        </p>
-      )}
-
-      {/* Liste des remèdes ou état vide */}
-      <RemedyResultList
-        remedies={filteredRemedies}
-        hasMatchingRemedies={matchedRemedies.length > 0}
-      />
-    </div>
+      </div>
+    </>
   );
 }
 

--- a/src/pages/RemedyResultDetails.jsx
+++ b/src/pages/RemedyResultDetails.jsx
@@ -1,6 +1,6 @@
 // tradimedika-v1/src/pages/RemedyResultDetails.jsx
 import { motion } from "framer-motion";
-import { Link, useParams } from "react-router-dom";
+import { Link, useLocation, useParams } from "react-router-dom";
 import RemedyResultNotFound from "../components/remedy/RemedyResultNotFound";
 import db from "../data/db.json";
 import { capitalizeFirstLetter } from "../utils/capitalizeFirstLetter";
@@ -17,6 +17,8 @@ import { getRemedyBySlug } from "../utils/remedyMatcher";
 
 function RemedyResultDetails() {
   const { slug } = useParams();
+  const location = useLocation();
+  const selectedSymptoms = location.state?.symptoms || [];
   const remedy = getRemedyBySlug(slug, db);
 
   // Si le remède n'existe pas, afficher composant NotFound
@@ -50,6 +52,7 @@ function RemedyResultDetails() {
       >
         <Link
           to="/remedes"
+          state={{ symptoms: selectedSymptoms }}
           aria-label="Retour aux résultats"
           className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:ring-2 focus:ring-emerald-300 focus:outline-none"
         >
@@ -77,15 +80,13 @@ function RemedyResultDetails() {
         className="mb-6 grid gap-6 lg:mb-8 lg:grid-cols-5 lg:gap-8"
       >
         {/* Image */}
-        <div className="lg:col-span-2">
-          <div className="aspect-video w-full overflow-hidden rounded-lg bg-neutral-100 shadow-md dark:bg-neutral-700">
+        <div className="lg:col-span-2 2xl:col-span-1">
+          <div className="aspect-square w-full overflow-hidden rounded-lg bg-neutral-300 shadow-md dark:bg-neutral-700">
             <motion.img
               src={remedy.image}
               alt={`Illustration de ${remedy.name}`}
-              className="h-full w-full object-cover"
+              className="mx-auto h-full w-2/3 object-scale-down p-6 lg:w-3/4 2xl:w-4/5"
               loading="lazy"
-              whileHover={{ scale: 1.05 }}
-              transition={{ duration: 0.3 }}
             />
           </div>
         </div>
@@ -217,7 +218,7 @@ function RemedyResultDetails() {
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 0.5 + index * 0.05 }}
-                className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-md dark:bg-emerald-700"
+                className="rounded-md bg-orange-100 px-3 py-2 text-sm font-medium text-yellow-800 shadow-md dark:bg-yellow-700 dark:text-yellow-100"
               >
                 {capitalizeFirstLetter(symptom, true)}
               </motion.span>
@@ -296,9 +297,9 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.7 }}
-          className="mb-6 rounded-lg border-l-4 border-amber-500 bg-amber-100 p-4 shadow-md transition duration-300 lg:p-6 dark:bg-amber-950"
+          className="mb-6 rounded-lg border-l-4 border-yellow-500 bg-yellow-100 p-4 shadow-md transition duration-300 lg:p-6 dark:bg-yellow-950"
         >
-          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-amber-800 lg:text-2xl dark:text-amber-200">
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-yellow-800 lg:text-2xl dark:text-yellow-200">
             <svg
               className="h-6 w-6"
               fill="none"
@@ -411,6 +412,7 @@ function RemedyResultDetails() {
         {/* Bouton Retour */}
         <Link
           to="/remedes"
+          state={{ symptoms: selectedSymptoms }}
           aria-label="Retour aux résultats"
           className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:ring-2 focus:ring-emerald-300 focus:outline-none"
         >

--- a/src/pages/RemedyResultDetails.jsx
+++ b/src/pages/RemedyResultDetails.jsx
@@ -1,54 +1,433 @@
 // tradimedika-v1/src/pages/RemedyResultDetails.jsx
 import { Link, useParams } from "react-router-dom";
+import { motion } from "framer-motion";
+import db from "../data/db.json";
+import { getRemedyBySlug } from "../utils/remedyMatcher";
+import RemedyResultNotFound from "../components/remedy/RemedyResultNotFound";
 
 /**
- * RemedyResultDetails Page - Placeholder
+ * RemedyResultDetails Page
  *
- * Future implementation (Issues #41, #38):
- * - Issue #41: Detailed remedy information display (properties, uses, contraindications)
- * - Issue #38: BreadCrumb component for navigation
- *
- * This page will display complete information about a specific natural remedy.
+ * Displays complete information about a specific natural remedy.
  * Layout (container, padding) is handled by LayoutRemedyResult.
+ *
+ * Issue #49: Implementation of detailed remedy page
  */
 
 function RemedyResultDetails() {
-  const { id } = useParams();
+  const { slug } = useParams();
+  const remedy = getRemedyBySlug(slug, db);
+
+  // Si le remède n'existe pas, afficher composant NotFound
+  if (!remedy) {
+    return <RemedyResultNotFound variant="remedy-not-found" />;
+  }
+
+  // Configuration des couleurs par type
+  const typeColors = {
+    aliment:
+      "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+    épice:
+      "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
+    plante:
+      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
+    boisson:
+      "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
+  };
 
   return (
-    <div className="text-dark dark:text-light w-full transition duration-300 ease-in-out">
-      <h1 className="mb-4 text-3xl font-bold lg:text-4xl">
-        Détails du Remède #{id}
-      </h1>
-      <p className="mb-8 text-lg text-neutral-600 dark:text-neutral-400">
-        Cette page affichera les informations complètes sur le remède
-        sélectionné.
-      </p>
+    <motion.article
+      initial={{ opacity: 0, y: 20 }}
+      animate={{ opacity: 1, y: 0 }}
+      transition={{ duration: 0.4 }}
+      className="text-dark dark:text-light w-full transition duration-300 ease-in-out"
+    >
+      {/* Header Hero Section */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.2 }}
+        className="mb-6 grid gap-6 lg:mb-8 lg:grid-cols-5 lg:gap-8"
+      >
+        {/* Image */}
+        <div className="lg:col-span-2">
+          <div className="aspect-video w-full overflow-hidden rounded-lg bg-neutral-100 shadow-md dark:bg-neutral-700">
+            <motion.img
+              src={remedy.image}
+              alt={`Illustration de ${remedy.name}`}
+              className="h-full w-full object-cover"
+              loading="lazy"
+              whileHover={{ scale: 1.05 }}
+              transition={{ duration: 0.3 }}
+            />
+          </div>
+        </div>
 
-      <div className="bg-light dark:bg-dark border-dark/20 dark:border-light/20 z-20 mb-8 rounded-lg border-2 border-dashed p-8 transition duration-300 ease-in-out">
-        <p className="text-sm text-neutral-500 dark:text-neutral-500">
-          🚧 Page en construction
-        </p>
-        <p className="mt-2 text-xs text-neutral-600 dark:text-neutral-400">
-          Issue #41 • Issue #38
-        </p>
-      </div>
+        {/* Metadata */}
+        <div className="lg:col-span-3">
+          {/* Badges */}
+          <div className="mb-3 flex flex-wrap items-center gap-2">
+            {/* Type Badge */}
+            <span
+              className={`rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition duration-300 ${typeColors[remedy.type] || typeColors.aliment}`}
+            >
+              {remedy.type}
+            </span>
 
-      <div className="flex flex-col gap-4 sm:flex-row">
+            {/* Pregnancy Safe Badge */}
+            {remedy.pregnancySafe === true && (
+              <span className="flex items-center gap-1.5 rounded-md bg-purple-100 px-3 py-1.5 text-xs font-semibold text-purple-800 transition duration-300 dark:bg-purple-900 dark:text-purple-200">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M4.318 6.318a4.5 4.5 0 000 6.364L12 20.364l7.682-7.682a4.5 4.5 0 00-6.364-6.364L12 7.636l-1.318-1.318a4.5 4.5 0 00-6.364 0z"
+                  />
+                </svg>
+                Grossesse OK
+              </span>
+            )}
+
+            {/* Children Age Badge */}
+            {remedy.childrenAge !== null && (
+              <span className="flex items-center gap-1.5 rounded-md bg-pink-100 px-3 py-1.5 text-xs font-semibold text-pink-800 transition duration-300 dark:bg-pink-900 dark:text-pink-200">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M14.828 14.828a4 4 0 01-5.656 0M9 10h.01M15 10h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                Enfants {remedy.childrenAge}+ ans
+              </span>
+            )}
+
+            {/* Verified Badge */}
+            {remedy.verifiedByProfessional && (
+              <span className="flex items-center gap-1.5 rounded-md bg-teal-100 px-3 py-1.5 text-xs font-semibold text-teal-800 transition duration-300 dark:bg-teal-900 dark:text-teal-200">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                Vérifié
+              </span>
+            )}
+          </div>
+
+          {/* Title */}
+          <h1 className="mb-3 text-3xl font-bold lg:text-4xl">
+            {remedy.name}
+          </h1>
+
+          {/* Description (courte pour mobile) */}
+          <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400 lg:text-base">
+            {remedy.description}
+          </p>
+        </div>
+      </motion.div>
+
+      {/* Bouton Retour */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+        className="mb-6"
+      >
         <Link
-          to="/remedies"
-          className="rounded-lg bg-emerald-600 px-6 py-3 text-center font-semibold text-white transition duration-200 hover:bg-emerald-700"
+          to="/remedes"
+          aria-label="Retour aux résultats"
+          className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-emerald-300"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+          Retour aux résultats
+        </Link>
+      </motion.div>
+
+      {/* Propriétés Section */}
+      {remedy.properties && remedy.properties.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.4 }}
+          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 dark:border-neutral-700 dark:bg-neutral-800 lg:p-6"
+        >
+          <h2 className="mb-4 text-2xl font-semibold lg:text-3xl">
+            Propriétés
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {remedy.properties.map((prop, index) => (
+              <motion.span
+                key={index}
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 0.4 + index * 0.05 }}
+                className="rounded-md bg-emerald-100 px-3 py-1.5 text-sm font-medium capitalize text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200"
+              >
+                {prop.name}
+              </motion.span>
+            ))}
+          </div>
+        </motion.section>
+      )}
+
+      {/* Symptômes Section */}
+      {remedy.symptoms && remedy.symptoms.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5 }}
+          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 dark:border-neutral-700 dark:bg-neutral-800 lg:p-6"
+        >
+          <h2 className="mb-4 text-2xl font-semibold lg:text-3xl">
+            Symptômes traités
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {remedy.symptoms.map((symptom, index) => (
+              <motion.span
+                key={index}
+                initial={{ opacity: 0, scale: 0.8 }}
+                animate={{ opacity: 1, scale: 1 }}
+                transition={{ delay: 0.5 + index * 0.05 }}
+                className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium capitalize text-white shadow-md dark:bg-emerald-700"
+              >
+                {symptom}
+              </motion.span>
+            ))}
+          </div>
+        </motion.section>
+      )}
+
+      {/* Utilisations Section */}
+      {remedy.uses && remedy.uses.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.6 }}
+          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 dark:border-neutral-700 dark:bg-neutral-800 lg:p-6"
+        >
+          <h2 className="mb-4 text-2xl font-semibold lg:text-3xl">
+            Utilisations
+          </h2>
+          <ul className="space-y-4">
+            {remedy.uses.map((use, index) => (
+              <motion.li
+                key={index}
+                initial={{ opacity: 0, x: -20 }}
+                animate={{ opacity: 1, x: 0 }}
+                transition={{ delay: 0.6 + index * 0.1 }}
+                className="border-l-4 border-emerald-500 pl-4"
+              >
+                <div className="mb-1 flex flex-wrap items-center gap-2 text-sm font-semibold text-neutral-700 dark:text-neutral-300">
+                  {/* Forme */}
+                  {use.form && use.form.length > 0 && (
+                    <span className="capitalize">
+                      {use.form.join(", ")}
+                    </span>
+                  )}
+                  {/* Dose */}
+                  {use.dose && use.dose.value && (
+                    <>
+                      <span className="text-neutral-400">•</span>
+                      <span>
+                        {use.dose.value} {use.dose.unit}
+                      </span>
+                    </>
+                  )}
+                  {/* Fréquence */}
+                  {use.frequency && use.frequency.value && (
+                    <>
+                      <span className="text-neutral-400">•</span>
+                      <span>
+                        {use.frequency.value}x/{use.frequency.unit}
+                      </span>
+                    </>
+                  )}
+                  {/* Durée */}
+                  {use.duration && use.duration.value && (
+                    <>
+                      <span className="text-neutral-400">•</span>
+                      <span>
+                        Pendant {use.duration.value} {use.duration.unit}
+                      </span>
+                    </>
+                  )}
+                </div>
+                {use.description && (
+                  <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400">
+                    {use.description}
+                  </p>
+                )}
+              </motion.li>
+            ))}
+          </ul>
+        </motion.section>
+      )}
+
+      {/* Contraindications Section */}
+      {remedy.contraindications && remedy.contraindications.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.7 }}
+          className="mb-6 rounded-lg border-l-4 border-red-500 bg-red-50 p-4 shadow-md transition duration-300 dark:bg-red-900/20 lg:p-6"
+        >
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-red-800 dark:text-red-300 lg:text-2xl">
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z"
+              />
+            </svg>
+            Contraindications
+          </h2>
+          <ul className="list-disc space-y-1 pl-5">
+            {remedy.contraindications.map((contraindication, index) => (
+              <li
+                key={index}
+                className="text-sm capitalize leading-relaxed text-red-700 dark:text-red-300"
+              >
+                {contraindication}
+              </li>
+            ))}
+          </ul>
+        </motion.section>
+      )}
+
+      {/* Tips Section */}
+      {remedy.tips && remedy.tips.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.8 }}
+          className="mb-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-4 shadow-md transition duration-300 dark:bg-blue-900/20 lg:p-6"
+        >
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-blue-800 dark:text-blue-300 lg:text-2xl">
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M9.663 17h4.673M12 3v1m6.364 1.636l-.707.707M21 12h-1M4 12H3m3.343-5.657l-.707-.707m2.828 9.9a5 5 0 117.072 0l-.548.547A3.374 3.374 0 0014 18.469V19a2 2 0 11-4 0v-.531c0-.895-.356-1.754-.988-2.386l-.548-.547z"
+              />
+            </svg>
+            Conseils pratiques
+          </h2>
+          <ul className="list-disc space-y-1 pl-5">
+            {remedy.tips.map((tip, index) => (
+              <li
+                key={index}
+                className="text-sm leading-relaxed text-blue-700 dark:text-blue-300"
+              >
+                {tip}
+              </li>
+            ))}
+          </ul>
+        </motion.section>
+      )}
+
+      {/* Allergènes Section */}
+      {remedy.allergens && remedy.allergens.length > 0 && (
+        <motion.section
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.9 }}
+          className="mb-6 rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4 shadow-md transition duration-300 dark:bg-yellow-900/20 lg:p-6"
+        >
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-yellow-800 dark:text-yellow-300 lg:text-2xl">
+            <svg
+              className="h-6 w-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+              />
+            </svg>
+            Allergènes potentiels
+          </h2>
+          <div className="flex flex-wrap gap-2">
+            {remedy.allergens.map((allergen, index) => (
+              <span
+                key={index}
+                className="rounded-md bg-yellow-200 px-3 py-1.5 text-sm font-medium capitalize text-yellow-900 dark:bg-yellow-800 dark:text-yellow-100"
+              >
+                {allergen}
+              </span>
+            ))}
+          </div>
+        </motion.section>
+      )}
+
+      {/* Footer Navigation */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 1 }}
+        className="flex flex-col gap-4 sm:flex-row"
+      >
+        <Link
+          to="/remedes"
+          className="rounded-lg bg-emerald-600 px-6 py-3 text-center font-semibold text-white transition duration-200 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-300"
         >
           ← Retour aux résultats
         </Link>
         <Link
           to="/"
-          className="rounded-lg border-2 border-emerald-600 px-6 py-3 text-center font-semibold text-emerald-600 transition duration-200 hover:bg-emerald-50 dark:hover:bg-emerald-950"
+          className="rounded-lg border-2 border-emerald-600 px-6 py-3 text-center font-semibold text-emerald-600 transition duration-200 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:hover:bg-emerald-950"
         >
           Nouvelle recherche
         </Link>
-      </div>
-    </div>
+      </motion.div>
+    </motion.article>
   );
 }
 

--- a/src/pages/RemedyResultDetails.jsx
+++ b/src/pages/RemedyResultDetails.jsx
@@ -1,9 +1,10 @@
 // tradimedika-v1/src/pages/RemedyResultDetails.jsx
-import { Link, useParams } from "react-router-dom";
 import { motion } from "framer-motion";
-import db from "../data/db.json";
-import { getRemedyBySlug } from "../utils/remedyMatcher";
+import { Link, useParams } from "react-router-dom";
 import RemedyResultNotFound from "../components/remedy/RemedyResultNotFound";
+import db from "../data/db.json";
+import { capitalizeFirstLetter } from "../utils/capitalizeFirstLetter";
+import { getRemedyBySlug } from "../utils/remedyMatcher";
 
 /**
  * RemedyResultDetails Page
@@ -26,13 +27,11 @@ function RemedyResultDetails() {
   // Configuration des couleurs par type
   const typeColors = {
     aliment:
-      "bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-200",
+      "bg-yellow-100 text-yellow-800 dark:bg-yellow-900 dark:text-yellow-200",
+    boisson: "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
     épice:
       "bg-orange-100 text-orange-800 dark:bg-orange-900 dark:text-orange-200",
-    plante:
-      "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
-    boisson:
-      "bg-cyan-100 text-cyan-800 dark:bg-cyan-900 dark:text-cyan-200",
+    plante: "bg-green-100 text-green-800 dark:bg-green-900 dark:text-green-200",
   };
 
   return (
@@ -42,6 +41,34 @@ function RemedyResultDetails() {
       transition={{ duration: 0.4 }}
       className="text-dark dark:text-light w-full transition duration-300 ease-in-out"
     >
+      {/* Bouton Retour */}
+      <motion.div
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        transition={{ delay: 0.3 }}
+        className="mb-6"
+      >
+        <Link
+          to="/remedes"
+          aria-label="Retour aux résultats"
+          className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:ring-2 focus:ring-emerald-300 focus:outline-none"
+        >
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+          Retour aux résultats
+        </Link>
+      </motion.div>
       {/* Header Hero Section */}
       <motion.div
         initial={{ opacity: 0 }}
@@ -69,14 +96,34 @@ function RemedyResultDetails() {
           <div className="mb-3 flex flex-wrap items-center gap-2">
             {/* Type Badge */}
             <span
-              className={`rounded-md px-3 py-1.5 text-xs font-semibold uppercase tracking-wide transition duration-300 ${typeColors[remedy.type] || typeColors.aliment}`}
+              className={`rounded-md px-3 py-1.5 text-xs font-semibold tracking-wide uppercase transition duration-300 ${typeColors[remedy.type] || typeColors.aliment}`}
             >
               {remedy.type}
             </span>
 
+            {/* Verified Badge */}
+            {remedy.verifiedByProfessional && (
+              <span className="flex items-center gap-1.5 rounded-md bg-sky-100 px-3 py-1.5 text-xs font-semibold text-sky-800 transition duration-300 dark:bg-sky-900 dark:text-sky-200">
+                <svg
+                  className="h-4 w-4"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                  />
+                </svg>
+                Vérifié
+              </span>
+            )}
+
             {/* Pregnancy Safe Badge */}
             {remedy.pregnancySafe === true && (
-              <span className="flex items-center gap-1.5 rounded-md bg-purple-100 px-3 py-1.5 text-xs font-semibold text-purple-800 transition duration-300 dark:bg-purple-900 dark:text-purple-200">
+              <span className="flex items-center gap-1.5 rounded-md bg-lime-100 px-3 py-1.5 text-xs font-semibold text-lime-800 transition duration-300 dark:bg-lime-900 dark:text-lime-200">
                 <svg
                   className="h-4 w-4"
                   fill="none"
@@ -96,7 +143,7 @@ function RemedyResultDetails() {
 
             {/* Children Age Badge */}
             {remedy.childrenAge !== null && (
-              <span className="flex items-center gap-1.5 rounded-md bg-pink-100 px-3 py-1.5 text-xs font-semibold text-pink-800 transition duration-300 dark:bg-pink-900 dark:text-pink-200">
+              <span className="flex items-center gap-1.5 rounded-md bg-blue-100 px-3 py-1.5 text-xs font-semibold text-blue-800 transition duration-300 dark:bg-blue-900 dark:text-blue-200">
                 <svg
                   className="h-4 w-4"
                   fill="none"
@@ -113,67 +160,16 @@ function RemedyResultDetails() {
                 Enfants {remedy.childrenAge}+ ans
               </span>
             )}
-
-            {/* Verified Badge */}
-            {remedy.verifiedByProfessional && (
-              <span className="flex items-center gap-1.5 rounded-md bg-teal-100 px-3 py-1.5 text-xs font-semibold text-teal-800 transition duration-300 dark:bg-teal-900 dark:text-teal-200">
-                <svg
-                  className="h-4 w-4"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-                  />
-                </svg>
-                Vérifié
-              </span>
-            )}
           </div>
 
           {/* Title */}
-          <h1 className="mb-3 text-3xl font-bold lg:text-4xl">
-            {remedy.name}
-          </h1>
+          <h1 className="mb-3 text-3xl font-bold lg:text-4xl">{remedy.name}</h1>
 
           {/* Description (courte pour mobile) */}
-          <p className="text-sm leading-relaxed text-neutral-600 dark:text-neutral-400 lg:text-base">
+          <p className="text-sm leading-relaxed text-neutral-600 lg:text-base dark:text-neutral-400">
             {remedy.description}
           </p>
         </div>
-      </motion.div>
-
-      {/* Bouton Retour */}
-      <motion.div
-        initial={{ opacity: 0 }}
-        animate={{ opacity: 1 }}
-        transition={{ delay: 0.3 }}
-        className="mb-6"
-      >
-        <Link
-          to="/remedes"
-          aria-label="Retour aux résultats"
-          className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:outline-none focus:ring-2 focus:ring-emerald-300"
-        >
-          <svg
-            className="h-5 w-5"
-            fill="none"
-            stroke="currentColor"
-            viewBox="0 0 24 24"
-          >
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M10 19l-7-7m0 0l7-7m-7 7h18"
-            />
-          </svg>
-          Retour aux résultats
-        </Link>
       </motion.div>
 
       {/* Propriétés Section */}
@@ -182,7 +178,7 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.4 }}
-          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 dark:border-neutral-700 dark:bg-neutral-800 lg:p-6"
+          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 lg:p-6 dark:border-neutral-700 dark:bg-neutral-800"
         >
           <h2 className="mb-4 text-2xl font-semibold lg:text-3xl">
             Propriétés
@@ -194,7 +190,7 @@ function RemedyResultDetails() {
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 0.4 + index * 0.05 }}
-                className="rounded-md bg-emerald-100 px-3 py-1.5 text-sm font-medium capitalize text-emerald-800 dark:bg-emerald-900 dark:text-emerald-200"
+                className="rounded-md bg-emerald-100 px-3 py-1.5 text-sm font-medium text-emerald-800 capitalize dark:bg-emerald-900 dark:text-emerald-200"
               >
                 {prop.name}
               </motion.span>
@@ -209,7 +205,7 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.5 }}
-          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 dark:border-neutral-700 dark:bg-neutral-800 lg:p-6"
+          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 lg:p-6 dark:border-neutral-700 dark:bg-neutral-800"
         >
           <h2 className="mb-4 text-2xl font-semibold lg:text-3xl">
             Symptômes traités
@@ -221,9 +217,9 @@ function RemedyResultDetails() {
                 initial={{ opacity: 0, scale: 0.8 }}
                 animate={{ opacity: 1, scale: 1 }}
                 transition={{ delay: 0.5 + index * 0.05 }}
-                className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium capitalize text-white shadow-md dark:bg-emerald-700"
+                className="rounded-md bg-emerald-600 px-3 py-2 text-sm font-medium text-white shadow-md dark:bg-emerald-700"
               >
-                {symptom}
+                {capitalizeFirstLetter(symptom, true)}
               </motion.span>
             ))}
           </div>
@@ -236,7 +232,7 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.6 }}
-          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 dark:border-neutral-700 dark:bg-neutral-800 lg:p-6"
+          className="mb-6 rounded-lg border border-neutral-200 bg-white p-4 shadow-md transition duration-300 lg:p-6 dark:border-neutral-700 dark:bg-neutral-800"
         >
           <h2 className="mb-4 text-2xl font-semibold lg:text-3xl">
             Utilisations
@@ -253,9 +249,7 @@ function RemedyResultDetails() {
                 <div className="mb-1 flex flex-wrap items-center gap-2 text-sm font-semibold text-neutral-700 dark:text-neutral-300">
                   {/* Forme */}
                   {use.form && use.form.length > 0 && (
-                    <span className="capitalize">
-                      {use.form.join(", ")}
-                    </span>
+                    <span className="capitalize">{use.form.join(", ")}</span>
                   )}
                   {/* Dose */}
                   {use.dose && use.dose.value && (
@@ -302,9 +296,9 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.7 }}
-          className="mb-6 rounded-lg border-l-4 border-red-500 bg-red-50 p-4 shadow-md transition duration-300 dark:bg-red-900/20 lg:p-6"
+          className="mb-6 rounded-lg border-l-4 border-amber-500 bg-amber-100 p-4 shadow-md transition duration-300 lg:p-6 dark:bg-amber-950"
         >
-          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-red-800 dark:text-red-300 lg:text-2xl">
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-amber-800 lg:text-2xl dark:text-amber-200">
             <svg
               className="h-6 w-6"
               fill="none"
@@ -324,7 +318,7 @@ function RemedyResultDetails() {
             {remedy.contraindications.map((contraindication, index) => (
               <li
                 key={index}
-                className="text-sm capitalize leading-relaxed text-red-700 dark:text-red-300"
+                className="text-sm leading-relaxed text-amber-800 capitalize dark:text-amber-200"
               >
                 {contraindication}
               </li>
@@ -339,9 +333,9 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.8 }}
-          className="mb-6 rounded-lg border-l-4 border-blue-500 bg-blue-50 p-4 shadow-md transition duration-300 dark:bg-blue-900/20 lg:p-6"
+          className="mb-6 rounded-lg border-l-4 border-sky-500 bg-sky-50 p-4 shadow-md transition duration-300 lg:p-6 dark:bg-sky-900/20"
         >
-          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-blue-800 dark:text-blue-300 lg:text-2xl">
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-sky-800 lg:text-2xl dark:text-sky-300">
             <svg
               className="h-6 w-6"
               fill="none"
@@ -361,7 +355,7 @@ function RemedyResultDetails() {
             {remedy.tips.map((tip, index) => (
               <li
                 key={index}
-                className="text-sm leading-relaxed text-blue-700 dark:text-blue-300"
+                className="text-sm leading-relaxed text-sky-800 dark:text-sky-300"
               >
                 {tip}
               </li>
@@ -376,9 +370,9 @@ function RemedyResultDetails() {
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
           transition={{ delay: 0.9 }}
-          className="mb-6 rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4 shadow-md transition duration-300 dark:bg-yellow-900/20 lg:p-6"
+          className="mb-6 rounded-lg border-l-4 border-yellow-500 bg-yellow-50 p-4 shadow-md transition duration-300 lg:p-6 dark:bg-yellow-900/20"
         >
-          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-yellow-800 dark:text-yellow-300 lg:text-2xl">
+          <h2 className="mb-3 flex items-center gap-2 text-xl font-semibold text-yellow-800 lg:text-2xl dark:text-yellow-300">
             <svg
               className="h-6 w-6"
               fill="none"
@@ -398,7 +392,7 @@ function RemedyResultDetails() {
             {remedy.allergens.map((allergen, index) => (
               <span
                 key={index}
-                className="rounded-md bg-yellow-200 px-3 py-1.5 text-sm font-medium capitalize text-yellow-900 dark:bg-yellow-800 dark:text-yellow-100"
+                className="rounded-md bg-yellow-200 px-3 py-1.5 text-sm font-medium text-yellow-900 capitalize dark:bg-yellow-800 dark:text-yellow-100"
               >
                 {allergen}
               </span>
@@ -414,15 +408,30 @@ function RemedyResultDetails() {
         transition={{ delay: 1 }}
         className="flex flex-col gap-4 sm:flex-row"
       >
+        {/* Bouton Retour */}
         <Link
           to="/remedes"
-          className="rounded-lg bg-emerald-600 px-6 py-3 text-center font-semibold text-white transition duration-200 hover:bg-emerald-700 focus:outline-none focus:ring-2 focus:ring-emerald-300"
+          aria-label="Retour aux résultats"
+          className="inline-flex items-center gap-2 rounded-lg bg-emerald-600 px-6 py-3 font-semibold text-white shadow-md transition duration-200 hover:bg-emerald-700 hover:shadow-lg focus:ring-2 focus:ring-emerald-300 focus:outline-none"
         >
-          ← Retour aux résultats
+          <svg
+            className="h-5 w-5"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M10 19l-7-7m0 0l7-7m-7 7h18"
+            />
+          </svg>
+          Retour aux résultats
         </Link>
         <Link
           to="/"
-          className="rounded-lg border-2 border-emerald-600 px-6 py-3 text-center font-semibold text-emerald-600 transition duration-200 hover:bg-emerald-50 focus:outline-none focus:ring-2 focus:ring-emerald-300 dark:hover:bg-emerald-950"
+          className="rounded-lg border-2 border-emerald-600 px-6 py-3 text-center font-semibold text-emerald-700 transition duration-200 hover:bg-emerald-600 hover:text-white focus:ring-2 focus:ring-emerald-300 focus:outline-none dark:hover:bg-emerald-600 dark:hover:text-white"
         >
           Nouvelle recherche
         </Link>

--- a/src/routes/Router.jsx
+++ b/src/routes/Router.jsx
@@ -13,12 +13,12 @@ import RemedyResultDetails from "../pages/RemedyResultDetails";
  * Routes:
  * - / → Home page (Hero component)
  * - /remedies → Remedy results list (nested in LayoutRemedyResult)
- * - /remedies/:id → Remedy detail page (nested in LayoutRemedyResult)
+ * - /remedies/:slug → Remedy detail page (nested in LayoutRemedyResult)
  * - * → NotFound page (404 error)
  *
  * Layout Structure:
  * - LayoutApp: Global layout (Header + Outlet + Footer) wraps all routes
- * - LayoutRemedyResult: Specific layout for remedy pages (future: BreadCrumb)
+ * - LayoutRemedyResult: Specific layout for remedy pages (includes BreadCrumb)
  */
 
 function Router() {
@@ -26,9 +26,9 @@ function Router() {
     <Routes>
       <Route element={<LayoutApp />}>
         <Route index element={<Home />} />
-        <Route path="remedies" element={<LayoutRemedyResult />}>
+        <Route path="remedes" element={<LayoutRemedyResult />}>
           <Route index element={<RemedyResult />} />
-          <Route path=":id" element={<RemedyResultDetails />} />
+          <Route path=":slug" element={<RemedyResultDetails />} />
         </Route>
         <Route path="*" element={<NotFound />} />
       </Route>

--- a/src/utils/capitalizeFirstLetter.js
+++ b/src/utils/capitalizeFirstLetter.js
@@ -1,0 +1,7 @@
+export const capitalizeFirstLetter = (str, lowerRest = false) => {
+  const [first, ...rest] = str;
+  return (
+    first.toUpperCase() +
+    (lowerRest ? rest.join("").toLowerCase() : rest.join(""))
+  );
+};

--- a/src/utils/remedyMatcher.js
+++ b/src/utils/remedyMatcher.js
@@ -114,9 +114,7 @@ export function getRemedyById(id, database) {
 
   // Vérifier que la conversion a réussi
   if (isNaN(numericId)) {
-    console.warn(
-      `[remedyMatcher] ID "${id}" n'est pas convertible en nombre`,
-    );
+    console.warn(`[remedyMatcher] ID "${id}" n'est pas convertible en nombre`);
     return null;
   }
 
@@ -124,9 +122,7 @@ export function getRemedyById(id, database) {
   const remedy = database.find((item) => item.id === numericId);
 
   if (!remedy) {
-    console.warn(
-      `[remedyMatcher] Aucun remède trouvé avec l'ID ${numericId}`,
-    );
+    console.warn(`[remedyMatcher] Aucun remède trouvé avec l'ID ${numericId}`);
     return null;
   }
 
@@ -187,9 +183,7 @@ export function getRemedyBySlug(slug, database) {
   });
 
   if (!remedy) {
-    console.warn(
-      `[remedyMatcher] Aucun remède trouvé avec le slug "${slug}"`,
-    );
+    console.warn(`[remedyMatcher] Aucun remède trouvé avec le slug "${slug}"`);
     return null;
   }
 

--- a/src/utils/remedyMatcher.js
+++ b/src/utils/remedyMatcher.js
@@ -85,3 +85,113 @@ export function findMatchingRemedies(selectedSymptoms, database) {
 
   return matches;
 }
+
+/**
+ * Récupère un remède par son ID depuis la base de données
+ *
+ * @param {string|number} id - L'ID du remède à récupérer
+ * @param {Array} database - Base de données des remèdes (db.json)
+ * @returns {Object|null} - Le remède trouvé ou null
+ *
+ * @example
+ * const remedy = getRemedyById("0", db);
+ * const remedy = getRemedyById(0, db);
+ */
+export function getRemedyById(id, database) {
+  // Validation des entrées
+  if (id === undefined || id === null || id === "") {
+    console.warn("[remedyMatcher] ID invalide fourni à getRemedyById");
+    return null;
+  }
+
+  if (!Array.isArray(database) || database.length === 0) {
+    console.error("[remedyMatcher] Base de données invalide ou vide");
+    return null;
+  }
+
+  // Convertir l'ID en nombre (vient de useParams comme string)
+  const numericId = Number(id);
+
+  // Vérifier que la conversion a réussi
+  if (isNaN(numericId)) {
+    console.warn(
+      `[remedyMatcher] ID "${id}" n'est pas convertible en nombre`,
+    );
+    return null;
+  }
+
+  // Rechercher le remède
+  const remedy = database.find((item) => item.id === numericId);
+
+  if (!remedy) {
+    console.warn(
+      `[remedyMatcher] Aucun remède trouvé avec l'ID ${numericId}`,
+    );
+    return null;
+  }
+
+  return remedy;
+}
+
+/**
+ * Génère un slug URL-safe depuis le nom d'un remède
+ *
+ * @param {string} name - Le nom du remède
+ * @returns {string} - Le slug formaté (lowercase, tirets, accents préservés)
+ *
+ * @example
+ * generateSlug("Citron") // "citron"
+ * generateSlug("Jus de Citron") // "jus-de-citron"
+ * generateSlug("Thé Vert") // "thé-vert"
+ */
+export function generateSlug(name) {
+  if (!name || typeof name !== "string") {
+    console.warn("[remedyMatcher] Nom invalide fourni à generateSlug");
+    return "";
+  }
+
+  return name
+    .toLowerCase() // Lowercase
+    .trim() // Supprime les espaces début/fin
+    .replace(/\s+/g, "-") // Espaces → tirets
+    .replace(/[^a-z0-9àâäéèêëïîôùûüÿçœ-]/g, ""); // Garde lettres, chiffres, accents français, tirets
+}
+
+/**
+ * Récupère un remède par son slug depuis la base de données
+ *
+ * @param {string} slug - Le slug du remède (ex: "citron", "thé-vert")
+ * @param {Array} database - Base de données des remèdes (db.json)
+ * @returns {Object|null} - Le remède trouvé ou null
+ *
+ * @example
+ * const remedy = getRemedyBySlug("citron", db);
+ * const remedy = getRemedyBySlug("thé-vert", db);
+ */
+export function getRemedyBySlug(slug, database) {
+  // Validation des entrées
+  if (!slug || typeof slug !== "string") {
+    console.warn("[remedyMatcher] Slug invalide fourni à getRemedyBySlug");
+    return null;
+  }
+
+  if (!Array.isArray(database) || database.length === 0) {
+    console.error("[remedyMatcher] Base de données invalide ou vide");
+    return null;
+  }
+
+  // Rechercher le remède dont le slug correspond
+  const remedy = database.find((item) => {
+    if (!item.name) return false;
+    return generateSlug(item.name) === slug;
+  });
+
+  if (!remedy) {
+    console.warn(
+      `[remedyMatcher] Aucun remède trouvé avec le slug "${slug}"`,
+    );
+    return null;
+  }
+
+  return remedy;
+}


### PR DESCRIPTION
## User Story

En tant que visiteur du site, je veux que mes résultats de recherche persistent lorsque je navigue entre la liste des remèdes et les pages de détails, afin de pouvoir consulter plusieurs remèdes sans perdre ma recherche initiale. Je veux également que les images des remèdes s'affichent en entier sans être coupées pour une meilleure expérience visuelle.

## Tâches

### Navigation State Persistence
- [x] Passer selectedSymptoms à travers la chaîne de navigation via React Router state
- [x] Ajouter la prop selectedSymptoms au composant RemedyResultList
- [x] Ajouter la prop selectedSymptoms au composant RemedyCard
- [x] Mettre à jour RemedyResultDetails pour recevoir les symptômes via location.state
- [x] Corriger le bouton "Retour aux résultats" du haut pour passer le state
- [x] Corriger le bouton "Retour aux résultats" du bas pour passer le state
- [x] Corriger le composant BreadCrumb pour préserver le state sur le lien "Remèdes"
- [x] Mettre à jour les PropTypes pour tous les composants modifiés

### Image Display Improvements
- [x] Changer le ratio d'aspect de 16:9 à 1:1 (aspect-square) dans RemedyCard
- [x] Changer le ratio d'aspect de 16:9 à 1:1 (aspect-square) dans RemedyResultDetails
- [x] Utiliser object-scale-down au lieu de object-cover pour afficher les icônes en entier
- [x] Ajouter du padding pour un meilleur espacement visuel

### Bug Fixes
- [x] Ajouter les imports manquants (motion, Link) à RemedyResult.jsx
- [x] Créer buttonStyles.js pour la réutilisation des styles de boutons

### Release
- [x] Exécuter la validation ESLint
- [x] Exécuter le formatage Prettier
- [x] Bumper la version à 0.9.1 dans package.json

## Bugs potentiels anticipés

- **Accès direct via URL** : L'accès direct à une page de détails (ex: `/remedes/citron`) affichera un bouton "Retour" qui mène vers des résultats vides - c'est un comportement attendu car il n'y a pas de contexte de recherche
- **Rafraîchissement de page** : Un refresh de page perd le state - c'est le comportement standard de React Router location.state et acceptable
- **Compatibilité navigateur** : object-scale-down est supporté par tous les navigateurs modernes (IE11+ non supporté)

## Bugs actifs

Aucun

## Fichiers / Composants

### Create
- `src/constants/buttonStyles.js` - Constantes de styles de boutons réutilisables

### Update
- `src/pages/RemedyResult.jsx` - Ajout de la prop selectedSymptoms à RemedyResultList, imports motion/Link
- `src/components/remedy/RemedyResultList.jsx` - Reçoit et propage selectedSymptoms aux cartes
- `src/components/remedy/RemedyCard.jsx` - Passe selectedSymptoms via Link state à la page de détails, aspect-square, object-scale-down
- `src/pages/RemedyResultDetails.jsx` - Reçoit symptoms de location.state et les retourne dans les boutons "Retour", aspect-square, object-scale-down
- `src/components/navigation/BreadCrumb.jsx` - Préserve le state lors du clic sur le lien "Remèdes" du fil d'Ariane
- `src/components/filter/FilterTag.jsx` - Utilisation de buttonStyles
- `src/components/filter/ListFilterTag.jsx` - Utilisation de buttonStyles
- `src/components/sections/Hero.jsx` - Utilisation de buttonStyles
- `src/components/tag/SymptomTag.jsx` - Utilisation de buttonStyles
- `src/utils/remedyMatcher.js` - Optimisations mineures
- `package.json` - Version 0.9.0 → 0.9.1
