### PR TITLE
[#53] fix(breadcrumb): correct unusual characters in accents, hyphens, and slugs

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -19,5 +19,5 @@ src/
 │   └── components/     # Composants spécifiques au layout (LogoTradimedika)
 ├── pages/              # Pages de l'application (Home, RemedyResult, RemedyResultDetails, NotFound)
 ├── routes/             # Configuration du routage React Router (Router.jsx)
-└── utils/              # Fonctions utilitaires (normalizeSymptom, remedyMatcher avec slug generation)
+└── utils/              # Fonctions utilitaires (normalizeSymptom, remedyMatcher avec slug generation, formatSegmentLabel pour BreadCrumb)
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,63 @@
 
 ---
 
+## [0.11.1] - 2025-12-11
+
+### <u>add:</u>
+
+- Added `src/utils/formatSegmentLabel.js` utility function for BreadCrumb label formatting
+- Added `decodeURIComponent()` logic in `getRemedyBySlug()` to handle URL-encoded slugs (ex: `th%C3%A9-vert` → `thé-vert`)
+- Added intelligent fallback in `segmentToLabel()` using `formatSegmentLabel()` for unknown segments
+
+### <u>update:</u>
+
+- Updated `src/utils/remedyMatcher.js` to decode URI-encoded slugs before matching remedies
+- Updated `src/components/navigation/BreadCrumb.jsx` to use `formatSegmentLabel()` for better label display
+- Updated `segmentToLabel()` function with 3-level priority system (remedy name > static labels > formatted segment)
+- Updated JSDoc documentation in `getRemedyBySlug()` to reflect new URI decoding behavior
+- Updated `package.json` version from `0.11.0` to `0.11.1`
+- Updated `README.md` version badge from `0.11.0` to `0.11.1`
+- Updated `ARCHITECTURE.md` to include `formatSegmentLabel` in utils section
+
+### <u>fix:</u>
+
+- Fixed BreadCrumb displaying corrupted characters with URL-encoded accents (ex: `th%C3%A9-vert` now correctly shows "Thé Vert")
+- Fixed BreadCrumb showing raw slugs instead of formatted labels for unknown remedies (ex: `huile-de-coco` → "Huile De Coco")
+- Fixed `getRemedyBySlug()` failing to match remedies when browser encodes accents in URLs
+- Fixed missing capitalization and space conversion in BreadCrumb labels
+
+### <u>refactor:</u>
+
+- Refactored BreadCrumb label transformation logic into dedicated `formatSegmentLabel()` utility
+- Refactored `segmentToLabel()` to use structured priority system with clear documentation
+
+### <u>optimization:</u>
+
+- Optimized BreadCrumb display with try/catch error handling for URI decoding failures
+- Improved remedy matching robustness by handling both encoded and non-encoded URL slugs
+
+### <u>standardization:</u>
+
+- Standardized BreadCrumb label formatting with consistent capitalization rules
+- Standardized URI decoding pattern across slug matching system
+
+### <u>features:</u>
+
+- **Smart URI Decoding**: BreadCrumb automatically decodes URL-encoded characters (`%C3%A9` → `é`)
+- **Intelligent Label Formatting**: Unknown segments display as formatted labels (hyphens → spaces, capitalized)
+- **Robust Slug Matching**: Remedies can be found with both encoded and non-encoded URLs
+- **French Accent Support**: Full support for French accents in URLs and BreadCrumb display
+- **Graceful Fallback**: If remedy not found in database, BreadCrumb still displays clean formatted label
+
+### <u>issues resolved:</u>
+
+- GitHub Issue #53: Correction of unusual characters in BreadCrumb (accents, hyphens, slugs)
+- User request: Fix corrupted accent display in navigation breadcrumb
+- Fixed BreadCrumb showing `th%C3%A9-vert` instead of "Thé Vert"
+- Fixed BreadCrumb showing `menthe-poivree` instead of "Menthe Poivrée"
+
+---
+
 ## [0.11.0] - 2025-12-11
 
 ### <u>add:</u>

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [🌐 **Voir le site**](https://pierremaze.github.io/tradimedika/) • [🐛 **Signaler un bug**](https://github.com/PierreMaze/) • [💬 **Discuter**](https://www.linkedin.com/in/pierremazelaygue/)
 
-[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.11.0)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
+[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.11.1)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
 
 </div>
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tradimedika",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "homepage": "http://pierremaze.github.io/tradimedika",
   "prettier": {

--- a/src/components/navigation/BreadCrumb.jsx
+++ b/src/components/navigation/BreadCrumb.jsx
@@ -4,6 +4,7 @@ import { IoChevronForward } from "react-icons/io5";
 import { NavLink, useLocation, useParams } from "react-router-dom";
 import { LINK_INTERNAL_STYLES } from "../../constants/linkStyles";
 import db from "../../data/db.json";
+import { formatSegmentLabel } from "../../utils/formatSegmentLabel";
 import { getRemedyBySlug } from "../../utils/remedyMatcher";
 
 /**
@@ -27,21 +28,35 @@ import { getRemedyBySlug } from "../../utils/remedyMatcher";
 
 /**
  * Convert URL segment to readable label
- * @param {string} segment - URL segment (e.g., "remedies", "citron")
+ *
+ * Priorité de transformation :
+ * 1. Si c'est un slug et qu'on a le nom du remède depuis la DB → utiliser le nom exact
+ * 2. Si c'est un segment avec label statique (ex: "remedes") → utiliser le label
+ * 3. Sinon → formater le segment avec formatSegmentLabel (décodage URI + capitalisation)
+ *
+ * @param {string} segment - URL segment (e.g., "remedes", "citron", "thé-vert", "th%C3%A9-vert")
  * @param {boolean} isSlug - Whether segment is a remedy slug
  * @param {string|null} remedyName - Name of the remedy if found
  * @returns {string} Human-readable label
  */
 const segmentToLabel = (segment, isSlug = false, remedyName = null) => {
+  // Priorité 1: Nom du remède depuis la DB (garantit l'exactitude)
   if (isSlug && remedyName) {
     return remedyName; // Affiche "Citron" au lieu de "citron"
   }
 
+  // Priorité 2: Labels statiques pour les routes connues
   const labels = {
     remedes: "Remèdes",
   };
 
-  return labels[segment] || segment;
+  if (labels[segment]) {
+    return labels[segment];
+  }
+
+  // Priorité 3: Formatage intelligent du segment
+  // (décode URI, remplace tirets par espaces, capitalise)
+  return formatSegmentLabel(segment);
 };
 
 /**

--- a/src/utils/formatSegmentLabel.js
+++ b/src/utils/formatSegmentLabel.js
@@ -1,0 +1,63 @@
+// src/utils/formatSegmentLabel.js
+
+/**
+ * Formate un segment d'URL en label lisible pour le BreadCrumb
+ *
+ * Transformations appliquées :
+ * 1. Décode les caractères URI encodés (ex: %C3%A9 → é)
+ * 2. Remplace les tirets par des espaces
+ * 3. Capitalise la première lettre de chaque mot
+ *
+ * @param {string} segment - Segment d'URL brut (ex: "thé-vert", "th%C3%A9-vert", "huile-de-coco")
+ * @returns {string} Label formaté (ex: "Thé Vert", "Huile De Coco")
+ *
+ * @example
+ * formatSegmentLabel("thé-vert") // "Thé Vert"
+ * formatSegmentLabel("th%C3%A9-vert") // "Thé Vert"
+ * formatSegmentLabel("huile-de-coco") // "Huile De Coco"
+ * formatSegmentLabel("menthe-poivr%C3%A9e") // "Menthe Poivrée"
+ */
+export function formatSegmentLabel(segment) {
+  // Validation des entrées
+  if (!segment || typeof segment !== "string") {
+    console.warn(
+      "[formatSegmentLabel] Segment invalide fourni à formatSegmentLabel",
+    );
+    return "";
+  }
+
+  try {
+    // 1. Décoder les caractères URI (ex: %C3%A9 → é)
+    const decoded = decodeURIComponent(segment);
+
+    // 2. Remplacer les tirets par des espaces
+    const withSpaces = decoded.replace(/-/g, " ");
+
+    // 3. Capitaliser la première lettre de chaque mot
+    const capitalized = withSpaces
+      .split(" ")
+      .map((word) => {
+        if (!word) return word; // Gérer les espaces multiples
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(" ");
+
+    return capitalized;
+  } catch (error) {
+    // Fallback si le décodage URI échoue
+    console.warn(
+      `[formatSegmentLabel] Erreur lors du décodage de "${segment}"`,
+      error,
+    );
+
+    // Continuer sans décodage URI
+    return segment
+      .replace(/-/g, " ")
+      .split(" ")
+      .map((word) => {
+        if (!word) return word;
+        return word.charAt(0).toUpperCase() + word.slice(1);
+      })
+      .join(" ");
+  }
+}


### PR DESCRIPTION
# [#53] fix(breadcrumb): correct unusual characters in accents, hyphens, and slugs

## User Story

En tant que visiteur du site, je veux que le fil d'Ariane affiche correctement les noms de pages et remèdes afin d'avoir une navigation claire et lisible, sans caractères corrompus.

## Tâches

- [x] Créer la fonction utilitaire `formatSegmentLabel.js` pour le formatage des labels
- [x] Améliorer `getRemedyBySlug()` dans `remedyMatcher.js` pour décoder les slugs URI
- [x] Améliorer `segmentToLabel()` dans `BreadCrumb.jsx` avec système de fallback intelligent
- [x] Tester le BreadCrumb avec différents scénarios (accents, slugs inconnus, etc.)
- [x] Valider que tous les tests passent avec `pnpm run validate-data`
- [x] Mettre à jour la documentation (CHANGELOG, README, ARCHITECTURE, package.json)

## Bugs potentiels anticipés

- Aucun bug potentiel identifié
- La fonction `decodeURIComponent()` est wrappée dans un try/catch pour gérer les erreurs de décodage
- Fallback gracieux en place si le décodage URI échoue

## Bugs actifs

- Aucun

## Fichiers / Composants

### Create
- `src/utils/formatSegmentLabel.js` - Nouvelle fonction utilitaire pour formater les segments d'URL en labels lisibles

### Update
- `src/utils/remedyMatcher.js` - Ajout du décodage URI dans `getRemedyBySlug()`
- `src/components/navigation/BreadCrumb.jsx` - Amélioration de `segmentToLabel()` avec fallback intelligent
- `ARCHITECTURE.md` - Ajout de `formatSegmentLabel` dans la section utils
- `CHANGELOG.md` - Documentation complète de la version 0.11.1
- `README.md` - Mise à jour du badge de version vers 0.11.1
- `package.json` - Bump version 0.11.0 → 0.11.1

### Delete
- Aucun fichier supprimé

### Fix
- Fix BreadCrumb affichant des caractères corrompus avec accents encodés (`th%C3%A9-vert` → "Thé Vert")
- Fix BreadCrumb montrant les slugs bruts au lieu de labels formatés (`huile-de-coco` → "Huile De Coco")
- Fix `getRemedyBySlug()` échouant à trouver des remèdes quand le navigateur encode les accents
- Fix capitalisation et conversion tirets-espaces manquantes dans les labels

### Refactor
- Refactorisation de la logique de transformation des labels du BreadCrumb dans une fonction utilitaire dédiée
- Refactorisation de `segmentToLabel()` avec un système de priorité à 3 niveaux (nom remède > labels statiques > segment formaté)

### Chore
- Aucune tâche de maintenance

## Issues

- Closes #53

## Summary

Cette PR résout le problème d'affichage de caractères inhabituels dans le fil d'Ariane (BreadCrumb) causé par l'encodage des URLs par les navigateurs.

**Changements clés :**
- 🆕 Nouvelle fonction `formatSegmentLabel()` pour le décodage URI et le formatage intelligent
- 🔧 Amélioration de `getRemedyBySlug()` pour gérer les slugs encodés et non-encodés
- ✨ Système de fallback à 3 niveaux dans `segmentToLabel()` pour un affichage propre
- 🧪 Tous les tests passent (ESLint + validation des données)

**Impact utilisateur :**
- ✅ Les accents français s'affichent correctement dans le BreadCrumb
- ✅ Les slugs inconnus sont formatés proprement
- ✅ Support complet des URLs encodées et non-encodées
- ✅ Navigation plus professionnelle et lisible

**Stats :**
- 7 fichiers modifiés
- 162 insertions (+), 8 suppressions (-)
- 1 nouveau fichier créé
