### PR TITLE
feat: masquer le filtre de symptômes pour un seul symptôme unique

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,35 @@
 
 ---
 
+## [0.31.0] - 2025-12-30
+
+### <u>Changed:</u>
+
+- Masquage automatique du filtre de symptômes lorsqu'un seul symptôme unique est présent dans les résultats
+- Amélioration de l'UX : interface épurée pour les recherches mono-symptôme
+- Modified `FilterRemedyResult.jsx` condition from `availableTags.length <= 1` to `uniqueSymptoms.length <= 1`
+
+### <u>Added:</u>
+
+- Tests unitaires complets pour `FilterRemedyResult.jsx` (9 scénarios critiques)
+  - Tests de rendu conditionnel : 1 vs 2+ symptômes uniques
+  - Tests des edge cases : tableau vide, symptômes vides
+  - Tests du callback `onFilterChange` même quand masqué
+  - Tests d'extraction et déduplication des symptômes
+
+### <u>Tests:</u>
+
+- 350 tests passing (18 test files)
+- Added 9 comprehensive unit tests for FilterRemedyResult component
+- Test coverage: conditional rendering, edge cases, callback behavior, symptom extraction
+
+### <u>Documentation:</u>
+
+- Updated version from `0.30.0` to `0.31.0`
+- Added implementation details to CHANGELOG
+
+---
+
 ## [0.30.0] - 2025-12-30
 
 ### <u>refactoring:</u>

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [🌐 **Voir le site**](https://pierremaze.github.io/tradimedika/) • [🐛 **Signaler un bug**](https://github.com/PierreMaze/) • [💬 **Discuter**](https://www.linkedin.com/in/pierremazelaygue/)
 
-[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.30.0)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
+[![TRADIMEDIKA](<https://img.shields.io/badge/TRADIMEDIKA-Bêta(0.31.0)-1a1a1a?style=for-the-badge&logo=leaflet&logoColor=00bd7e>)](https://pierremaze.github.io/tradimedika/)
 
 </div>
 
@@ -60,6 +60,11 @@
 ### 🏠 Page d'accueil
 
 - **Hero section** avec champs de texte pour la saisie des symptômes.
+
+### 🔍 Filtrage Intelligent des Résultats
+
+- **Affichage adaptatif** : Lorsque plusieurs symptômes uniques sont trouvés dans les remèdes, un système de filtrage apparaît automatiquement pour affiner les résultats.
+- **Interface épurée** : Si un seul symptôme correspond, le filtre est masqué pour simplifier l'interface.
 
 ### 📱 Responsive Design
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tradimedika",
   "private": true,
-  "version": "0.30.0",
+  "version": "0.31.0",
   "type": "module",
   "homepage": "http://pierremaze.github.io/tradimedika",
   "prettier": {

--- a/src/components/filter/FilterRemedyResult.jsx
+++ b/src/components/filter/FilterRemedyResult.jsx
@@ -70,8 +70,9 @@ export default function FilterRemedyResult({
     setActiveTag(tag);
   };
 
-  // Afficher seulement si au moins 2 tags (Tous + 1 symptôme minimum)
-  if (availableTags.length <= 1) {
+  // Masquer si un seul symptôme unique ou moins
+  // uniqueSymptoms.length <= 1 → Pas de choix de filtrage utile
+  if (uniqueSymptoms.length <= 1) {
     return null;
   }
 

--- a/src/components/filter/FilterRemedyResult.test.jsx
+++ b/src/components/filter/FilterRemedyResult.test.jsx
@@ -1,0 +1,243 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import FilterRemedyResult from "./FilterRemedyResult";
+
+vi.mock("./ListFilterTag", () => ({
+  default: ({ tags, activeTag, onTagClick }) => (
+    <div
+      data-testid="list-filter-tag"
+      role="group"
+      aria-label="Filtrer les remèdes par symptôme"
+    >
+      {tags.map((tag) => (
+        <button
+          key={tag}
+          onClick={() => onTagClick(tag)}
+          aria-pressed={tag === activeTag}
+        >
+          {tag === "all" ? "Tous" : tag.charAt(0).toUpperCase() + tag.slice(1)}
+        </button>
+      ))}
+    </div>
+  ),
+}));
+
+describe("FilterRemedyResult - Conditional Rendering", () => {
+  describe("Un seul symptôme unique", () => {
+    it("should NOT render when only one unique symptom exists", () => {
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+        {
+          remedy: { id: 2, name: "Gingembre" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+      ];
+
+      const { container } = render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={vi.fn()}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("Deux symptômes uniques ou plus", () => {
+    it("should render when two unique symptoms exist", () => {
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+        {
+          remedy: { id: 2, name: "Gingembre" },
+          matchCount: 1,
+          matchedSymptoms: ["stress"],
+        },
+      ];
+
+      render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("group", { name: /Filtrer les remèdes/i }),
+      ).toBeInTheDocument();
+    });
+
+    it("should render when multiple unique symptoms exist", () => {
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 2,
+          matchedSymptoms: ["fatigue", "stress"],
+        },
+        {
+          remedy: { id: 2, name: "Gingembre" },
+          matchCount: 1,
+          matchedSymptoms: ["nausée"],
+        },
+      ];
+
+      render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={vi.fn()}
+        />,
+      );
+
+      expect(
+        screen.getByRole("group", { name: /Filtrer les remèdes/i }),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("Edge cases", () => {
+    it("should NOT render when matchedRemedies is empty", () => {
+      const { container } = render(
+        <FilterRemedyResult matchedRemedies={[]} onFilterChange={vi.fn()} />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("should NOT render when all remedies have empty matchedSymptoms", () => {
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 0,
+          matchedSymptoms: [],
+        },
+      ];
+
+      const { container } = render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={vi.fn()}
+        />,
+      );
+
+      expect(container.firstChild).toBeNull();
+    });
+  });
+
+  describe("Callback behavior", () => {
+    it("should call onFilterChange with all remedies when single symptom", async () => {
+      const mockCallback = vi.fn();
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+      ];
+
+      render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={mockCallback}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockCallback).toHaveBeenCalledWith(matchedRemedies);
+      });
+    });
+
+    it("should call onFilterChange with all remedies initially when multiple symptoms", async () => {
+      const mockCallback = vi.fn();
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+        {
+          remedy: { id: 2, name: "Gingembre" },
+          matchCount: 1,
+          matchedSymptoms: ["stress"],
+        },
+      ];
+
+      render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={mockCallback}
+        />,
+      );
+
+      await waitFor(() => {
+        expect(mockCallback).toHaveBeenCalledWith(matchedRemedies);
+      });
+    });
+  });
+
+  describe("Symptoms extraction and sorting", () => {
+    it("should extract unique symptoms from matchedRemedies", () => {
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 2,
+          matchedSymptoms: ["fatigue", "stress"],
+        },
+        {
+          remedy: { id: 2, name: "Gingembre" },
+          matchCount: 2,
+          matchedSymptoms: ["stress", "nausée"],
+        },
+      ];
+
+      render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("Fatigue")).toBeInTheDocument();
+      expect(screen.getByText("Stress")).toBeInTheDocument();
+      expect(screen.getByText("Nausée")).toBeInTheDocument();
+    });
+
+    it("should not duplicate symptoms", () => {
+      const matchedRemedies = [
+        {
+          remedy: { id: 1, name: "Citron" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+        {
+          remedy: { id: 2, name: "Gingembre" },
+          matchCount: 1,
+          matchedSymptoms: ["fatigue"],
+        },
+        {
+          remedy: { id: 3, name: "Miel" },
+          matchCount: 1,
+          matchedSymptoms: ["stress"],
+        },
+      ];
+
+      render(
+        <FilterRemedyResult
+          matchedRemedies={matchedRemedies}
+          onFilterChange={vi.fn()}
+        />,
+      );
+
+      const fatigueButtons = screen.getAllByText("Fatigue");
+      expect(fatigueButtons).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
Amélioration de l'UX en masquant automatiquement le filtre de symptômes lorsqu'un seul symptôme unique est présent dans les résultats de recherche.

## Changes
### Code
- **FilterRemedyResult.jsx** (ligne 74) : Modification de la condition `availableTags.length <= 1` → `uniqueSymptoms.length <= 1`
  - Masque le filtre quand un seul symptôme unique existe
  - Gère automatiquement les edge cases (0 symptôme, normalisation)

### Tests
- **FilterRemedyResult.test.jsx** (NOUVEAU) : 9 scénarios critiques
  - ✅ Un seul symptôme unique → Masqué
  - ✅ Deux symptômes uniques → Affiché
  - ✅ Tableau vide → Masqué
  - ✅ Callback appelé même si masqué (critique pour affichage)
  - ✅ Extraction et déduplication des symptômes

### Documentation
- **CHANGELOG.md** : Entrée pour version 0.31.0
- **README.md** : Section "Filtrage Intelligent des Résultats"
- **package.json** : Bump version patch 0.30.0 → 0.31.0

## Test Plan
- [x] Tests unitaires passent (`pnpm test`) - 350 tests passing
- [x] Linting passe (`pnpm lint`)
- [x] Code formaté (`pnpm fix`)
- [ ] Test manuel : 1 symptôme → pas de filtre affiché
- [ ] Test manuel : 2+ symptômes → filtre affiché et fonctionnel
- [ ] Test manuel : Refresh de la page → comportement cohérent

## Related Issues
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>