### PR TITLE
fix: correct remedy frequency display format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 ---
 
+## [0.33.0] - 2025-12-30
+
+### <u>Fixed:</u>
+
+- Correction du format d'affichage des fréquences d'utilisation des remèdes
+  - Avant : "2x/fois par jour", "3x/tasses maximum par jour", "1x/jour"
+  - Après : "2 fois par jour", "3 tasses maximum par jour", "1 fois par jour"
+  - Cas spécial : "3x/heures (espacer)" → "Toutes les 3 heures"
+- Amélioration de la lisibilité des informations de posologie dans RemedyResultDetails
+
+### <u>Added:</u>
+
+- Nouvelle fonction utilitaire `formatFrequency()` dans `src/utils/formatFrequency.js`
+  - Gère dynamiquement les formats de fréquence : "jour", "heures (espacer)", unités composées
+  - Validation stricte des entrées avec retour sûr
+  - Extensible pour futurs formats sans modification
+- Tests unitaires complets : 22 tests pour `formatFrequency.test.js`
+  - Formats standards, cas spéciaux, validation, extensibilité
+
+### <u>Changed:</u>
+
+- `RemedyResultDetails.jsx` utilise maintenant `formatFrequency()` pour afficher les fréquences (ligne 306)
+
+---
+
 ## [0.32.0] - 2025-12-30
 
 ### <u>Added:</u>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tradimedika",
   "private": true,
-  "version": "0.32.0",
+  "version": "0.33.0",
   "type": "module",
   "homepage": "http://pierremaze.github.io/tradimedika",
   "prettier": {

--- a/src/pages/RemedyResultDetails.jsx
+++ b/src/pages/RemedyResultDetails.jsx
@@ -15,6 +15,7 @@ import PregnancyTag from "../components/tag/PregnancyTag";
 import ChildrenAgeTag from "../components/tag/ChildrenAgeTag";
 import db from "../data/db.json";
 import { capitalizeFirstLetter } from "../utils/capitalizeFirstLetter";
+import { formatFrequency } from "../utils/formatFrequency";
 import { getRemedyBySlug } from "../utils/remedyMatcher";
 
 /**
@@ -302,9 +303,7 @@ function RemedyResultDetails() {
                     {use.frequency && use.frequency.value && (
                       <>
                         <span className="text-neutral-400">•</span>
-                        <span>
-                          {use.frequency.value}x/{use.frequency.unit}
-                        </span>
+                        <span>{formatFrequency(use.frequency)}</span>
                       </>
                     )}
                     {/* Durée */}

--- a/src/utils/formatFrequency.js
+++ b/src/utils/formatFrequency.js
@@ -1,0 +1,22 @@
+export const formatFrequency = (frequency) => {
+  if (
+    !frequency ||
+    typeof frequency !== "object" ||
+    !frequency.value ||
+    !frequency.unit
+  ) {
+    return "";
+  }
+
+  const { value, unit } = frequency;
+
+  if (unit === "heures (espacer)") {
+    return `Toutes les ${value} heures`;
+  }
+
+  if (unit === "jour") {
+    return `${value} fois par jour`;
+  }
+
+  return `${value} ${unit}`;
+};

--- a/src/utils/formatFrequency.test.js
+++ b/src/utils/formatFrequency.test.js
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import { formatFrequency } from "./formatFrequency";
+
+describe("formatFrequency", () => {
+  describe("Formats standards - fois par jour", () => {
+    it("doit formater '1 fois par jour'", () => {
+      expect(formatFrequency({ value: 1, unit: "fois par jour" })).toBe(
+        "1 fois par jour",
+      );
+    });
+
+    it("doit formater '2 fois par jour'", () => {
+      expect(formatFrequency({ value: 2, unit: "fois par jour" })).toBe(
+        "2 fois par jour",
+      );
+    });
+
+    it("doit formater '3 fois par jour'", () => {
+      expect(formatFrequency({ value: 3, unit: "fois par jour" })).toBe(
+        "3 fois par jour",
+      );
+    });
+  });
+
+  describe('Cas spécial - "jour" simple', () => {
+    it('doit convertir "1 jour" en "1 fois par jour"', () => {
+      expect(formatFrequency({ value: 1, unit: "jour" })).toBe(
+        "1 fois par jour",
+      );
+    });
+
+    it('doit convertir "2 jour" en "2 fois par jour"', () => {
+      expect(formatFrequency({ value: 2, unit: "jour" })).toBe(
+        "2 fois par jour",
+      );
+    });
+  });
+
+  describe('Cas spécial - "heures (espacer)"', () => {
+    it('doit formater "3 heures (espacer)" en "Toutes les 3 heures"', () => {
+      expect(formatFrequency({ value: 3, unit: "heures (espacer)" })).toBe(
+        "Toutes les 3 heures",
+      );
+    });
+
+    it("doit gérer 2 heures", () => {
+      expect(formatFrequency({ value: 2, unit: "heures (espacer)" })).toBe(
+        "Toutes les 2 heures",
+      );
+    });
+
+    it("doit gérer 4 heures", () => {
+      expect(formatFrequency({ value: 4, unit: "heures (espacer)" })).toBe(
+        "Toutes les 4 heures",
+      );
+    });
+
+    it("doit gérer 6 heures", () => {
+      expect(formatFrequency({ value: 6, unit: "heures (espacer)" })).toBe(
+        "Toutes les 6 heures",
+      );
+    });
+  });
+
+  describe("Cas spécial - unités composées", () => {
+    it('doit formater "3 tasses maximum par jour"', () => {
+      expect(
+        formatFrequency({ value: 3, unit: "tasses maximum par jour" }),
+      ).toBe("3 tasses maximum par jour");
+    });
+
+    it('doit formater "2 cuillères à café"', () => {
+      expect(formatFrequency({ value: 2, unit: "cuillères à café" })).toBe(
+        "2 cuillères à café",
+      );
+    });
+  });
+
+  describe("Validation des entrées", () => {
+    it("doit retourner '' si frequency est null", () => {
+      expect(formatFrequency(null)).toBe("");
+    });
+
+    it("doit retourner '' si frequency est undefined", () => {
+      expect(formatFrequency(undefined)).toBe("");
+    });
+
+    it("doit retourner '' si frequency n'est pas un objet", () => {
+      expect(formatFrequency("invalid")).toBe("");
+      expect(formatFrequency(123)).toBe("");
+      expect(formatFrequency(true)).toBe("");
+    });
+
+    it("doit retourner '' si value est manquant", () => {
+      expect(formatFrequency({ unit: "jour" })).toBe("");
+    });
+
+    it("doit retourner '' si unit est manquant", () => {
+      expect(formatFrequency({ value: 1 })).toBe("");
+    });
+
+    it("doit retourner '' si value est null", () => {
+      expect(formatFrequency({ value: null, unit: "jour" })).toBe("");
+    });
+
+    it("doit retourner '' si value est 0", () => {
+      expect(formatFrequency({ value: 0, unit: "jour" })).toBe("");
+    });
+
+    it("doit retourner '' si unit est vide", () => {
+      expect(formatFrequency({ value: 1, unit: "" })).toBe("");
+    });
+  });
+
+  describe("Extensibilité - formats futurs", () => {
+    it("doit gérer 'capsules par repas' sans modification", () => {
+      expect(formatFrequency({ value: 2, unit: "capsules par repas" })).toBe(
+        "2 capsules par repas",
+      );
+    });
+
+    it("doit gérer 'gouttes (avant repas)' automatiquement", () => {
+      expect(formatFrequency({ value: 5, unit: "gouttes (avant repas)" })).toBe(
+        "5 gouttes (avant repas)",
+      );
+    });
+
+    it("doit gérer 'ml par prise' automatiquement", () => {
+      expect(formatFrequency({ value: 10, unit: "ml par prise" })).toBe(
+        "10 ml par prise",
+      );
+    });
+  });
+});


### PR DESCRIPTION
## 📝 Description

Correction du format d'affichage des fréquences d'utilisation des remèdes qui produisait des résultats grammaticalement incorrects.

## 🐛 Problème résolu

**Avant :**
- ❌ '3x/tasses maximum par jour'
- ❌ '2x/fois par jour'
- ❌ '1x/jour'
- ❌ '3x/heures (espacer)'

**Après :**
- ✅ '3 tasses maximum par jour'
- ✅ '2 fois par jour'
- ✅ '1 fois par jour'
- ✅ 'Toutes les 3 heures'

## 🔧 Changements techniques

### Ajouts
- `src/utils/formatFrequency.js` - Fonction utilitaire de formatage dynamique
- `src/utils/formatFrequency.test.js` - Tests unitaires complets (22 tests)

### Modifications
- `src/pages/RemedyResultDetails.jsx:306` - Utilisation de la nouvelle fonction
- `package.json` - Version 0.32.0 → 0.33.0
- `CHANGELOG.md` - Entrée pour v0.33.0

## ✅ Tests

- [x] Tests unitaires passent (`pnpm test`)
- [x] Lint sans erreur (`pnpm lint`)
- [x] Code formaté (`pnpm fix`)
- [x] Build réussi (`pnpm build`)
- [x] 22 nouveaux tests pour formatFrequency
- [x] 382 tests au total passent

## 📊 Impact

- ✅ Aucune modification de `db.json`
- ✅ Solution extensible pour formats futurs
- ✅ Impact minimal (2 lignes modifiées dans le composant)
- ✅ Zéro régression

Closes #80